### PR TITLE
JS prettier config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,12 @@
 dist/
 # Ignore anything in the public directory, which is expected to be delivered as-is.
 public/
+
+# Ignore the css directory (since it's mostly CSS provided by 3rd-party plugins)
+web_src/css/
+
+# Don't reformat data files, YAML files, or Markdown
+*.json
+*.yaml
+*.yml
+*.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,9 @@ dist/
 public/
 
 # Ignore the css directory (since it's mostly CSS provided by 3rd-party plugins)
-web_src/css/
+# except for main.css
+web_src/css/*
+!web_src/css/main.css
 
 # Don't reformat data files, YAML files, or Markdown
 *.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
- "semi": true,
- "singleQuote": true,
- "trailingComma": "es5",
- "printWidth": 120
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 120
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,18 +1,14 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import { defineConfig, globalIgnores } from 'eslint/config';
 
 export default defineConfig([
   globalIgnores(['dist']),
   {
     files: ['**/*.{js,jsx}'],
-    extends: [
-      js.configs.recommended,
-      reactHooks.configs.flat.recommended,
-      reactRefresh.configs.vite,
-    ],
+    extends: [js.configs.recommended, reactHooks.configs.flat.recommended, reactRefresh.configs.vite],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
@@ -26,4 +22,4 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
-])
+]);

--- a/index.html
+++ b/index.html
@@ -1,40 +1,48 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<meta name="mobile-web-app-capable" content="yes"/>
-<title>Supraland Maps</title>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <title>Supraland Maps</title>
 
-<link rel="icon" type="image/png" href="img/favicon.png" sizes="250x250"/>
+    <link rel="icon" type="image/png" href="img/favicon.png" sizes="250x250" />
 
-<meta property="og:image" content="img/favicon.png" />
-<meta property="og:site_name" content="SupraMaps" />
-<meta property="og:type" content="object" />
-<meta property="og:title" content="SupraMaps" />
-<meta property="og:description" content="SupraGames Interactive Maps" />
+    <meta property="og:image" content="img/favicon.png" />
+    <meta property="og:site_name" content="SupraMaps" />
+    <meta property="og:type" content="object" />
+    <meta property="og:title" content="SupraMaps" />
+    <meta property="og:description" content="SupraGames Interactive Maps" />
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/js/all.min.js" integrity="sha512-6BTOlkauINO65nLhXhthZMtepgJSghyimIalb+crKRPhvhmsCdnIuGcVbR5/aQY2A+260iC1OPy1oCdB6pSSwQ==" crossorigin="anonymous"></script>
+    <script
+      src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"
+      integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/js/all.min.js"
+      integrity="sha512-6BTOlkauINO65nLhXhthZMtepgJSghyimIalb+crKRPhvhmsCdnIuGcVbR5/aQY2A+260iC1OPy1oCdB6pSSwQ=="
+      crossorigin="anonymous"
+    ></script>
 
-<link rel="stylesheet" href="web_src/css/leaflet.css">
-<link rel="stylesheet" href="web_src/css/leaflet.toolbar.min.css">
-<link rel="stylesheet" href="web_src/css/L.Control.MousePosition.css">
-<link rel="stylesheet" href="web_src/css/Control.FullScreen.css">
-<link rel="stylesheet" href="web_src/css/leaflet-search.src.min.css">
+    <link rel="stylesheet" href="web_src/css/leaflet.css" />
+    <link rel="stylesheet" href="web_src/css/leaflet.toolbar.min.css" />
+    <link rel="stylesheet" href="web_src/css/L.Control.MousePosition.css" />
+    <link rel="stylesheet" href="web_src/css/Control.FullScreen.css" />
+    <link rel="stylesheet" href="web_src/css/leaflet-search.src.min.css" />
 
-<link rel="stylesheet" href="web_src/css/main.css"/>
+    <link rel="stylesheet" href="web_src/css/main.css" />
 
-<script src="js/lib/leaflet.min.js"></script>
-<script src="js/lib/leaflet.toolbar.min.js"></script>
-<script src="js/lib/L.TileLayer.Canvas.min.js"></script>
-<script src="js/lib/Control.FullScreen.js"></script>
-<script src="js/lib/leaflet-search.src.min.js"></script>
-<script src="js/lib/L.Control.MousePosition.js"></script>
-<script src="js/lib/leaflet.polylineDecorator.min.js"></script>
-</head>
-<body>
-  <div id="map"></div>
-  <script type="module" src="web_src/main.js"></script>
-</body>
+    <script src="js/lib/leaflet.min.js"></script>
+    <script src="js/lib/leaflet.toolbar.min.js"></script>
+    <script src="js/lib/L.TileLayer.Canvas.min.js"></script>
+    <script src="js/lib/Control.FullScreen.js"></script>
+    <script src="js/lib/leaflet-search.src.min.js"></script>
+    <script src="js/lib/L.Control.MousePosition.js"></script>
+    <script src="js/lib/leaflet.polylineDecorator.min.js"></script>
+  </head>
+  <body>
+    <div id="map"></div>
+    <script type="module" src="web_src/main.js"></script>
+  </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,15 +1,12 @@
-import { defineConfig } from 'vite'
-import react, { reactCompilerPreset } from '@vitejs/plugin-react'
-import babel from '@rolldown/plugin-babel'
+import { defineConfig } from 'vite';
+import react, { reactCompilerPreset } from '@vitejs/plugin-react';
+import babel from '@rolldown/plugin-babel';
 
 // https://vite.dev/config/
 export default defineConfig(() => {
   return {
     base: './',
-    plugins: [
-      react(),
-      babel({ presets: [reactCompilerPreset()] })
-    ],
+    plugins: [react(), babel({ presets: [reactCompilerPreset()] })],
     build: {
       sourcemap: true,
       rollupOptions: {
@@ -19,4 +16,4 @@ export default defineConfig(() => {
       },
     },
   };
-})
+});


### PR DESCRIPTION
Updates the JS [Prettier](https://prettier.io/docs/) configuration so that we can auto-format various source files, including `index.html`, JavaScript, and CSS.

The `.prettierignore` has been configured to ignore the 3rd-party libraries since there's no value in re-formatting those.

This PR also includes Prettier's reformat of some of the config files; I didn't go as far as running it over all the source files yet; we may want to see what the impact is first.

To run the reformatter over all the relevant files in the repo, run `npm run prettier`, or `npx prettier --write file1 file2 ....`.