### PR TITLE
Python type hinting and named parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dev = [
     "networkx>=3.6.1",
     "numpy>=2.4.4",
     "pillow>=12.2.0",
-    "pywin32>=311",
+    "pywin32>=311 ; sys_platform == 'win32'",
     "scikit-learn>=1.8.0",
 ]
 

--- a/scripts/gentiles.py
+++ b/scripts/gentiles.py
@@ -81,30 +81,27 @@ some suggestions where RAM may run out:
 http://www.imagemagick.org/Usage/files/#massive
 """
 
-import argparse
-import glob
 import logging
 import math
-import os
 import re
-import shutil
 import sys
 from argparse import ArgumentError, ArgumentParser
 from pathlib import Path
+from typing import Any, Optional
 
 from PIL import Image, UnidentifiedImageError
 
-LOG = logging.getLogger('gentiles')
+LOG = logging.getLogger(__name__)
 
 
-def power_of(num, base):
+def power_of(num: int, base: int) -> bool:
     """checks if a number is a power another"""
     while num % base == 0:
         num = num / base
     return num == 1
 
 
-def generate(image, outpath, zoom_level, resize_width, format='png'):
+def generate(image: Image, outpath: Path, zoom_level: int, resize_width: int, format: str = 'png') -> None:
     """
     generates map tiles from large image
     """
@@ -125,16 +122,15 @@ def generate(image, outpath, zoom_level, resize_width, format='png'):
     LOG.info('' + str(tile_width) + ' x ' + str(tile_width) + ' px tiles')
 
     # create output directory
-    outpath.mkdir(exist_ok=True)
     outpath = outpath.joinpath(str(zoom_level))
-    outpath.mkdir(exist_ok=True)
+    outpath.mkdir(exist_ok=True, parents=True)
 
     # Remove existing children
     for child in outpath.rglob('*.' + format):
         child.unlink()
 
     for x in range(num_tiles):
-        outpath.joinpath(str(x)).mkdir(exist_ok=True)
+        outpath.joinpath(str(x)).mkdir(exist_ok=True, parents=True)
         for y in range(num_tiles):
             left = tile_width * x
             top = tile_width * y
@@ -154,7 +150,7 @@ def generate(image, outpath, zoom_level, resize_width, format='png'):
     LOG.info('- done!')
 
 
-def zoom_range_type(value):
+def zoom_range_type(value: Any) -> tuple[int, int]:
     try:
         value = value.strip()
         if '-' in value:
@@ -176,7 +172,7 @@ def zoom_range_type(value):
     return (zoom_min, zoom_max)
 
 
-def positive_int_type(rawvalue):
+def positive_int_type(rawvalue: Any) -> int:
     try:
         value = int(rawvalue.strip())
     except ValueError:
@@ -186,15 +182,17 @@ def positive_int_type(rawvalue):
     return value
 
 
-def create_parser(prog_name):
-    parser = ArgumentParser(prog=prog_name, description="Generate map files for leaflet")
-    parser.add_argument('input_file', help='large image file to split (JPG, PNG, or TIFF)')
+def create_parser() -> ArgumentParser:
+    parser = ArgumentParser(description="Generate map files for leaflet")
+    parser.add_argument('input_file', type=Path, help='large image file to split (JPG, PNG, or TIFF)')
     parser.add_argument(
         'zoom_level',
         type=zoom_range_type,
         help='zoom level(s) to generate (0 to 18); either integer or range (ex: 2-6)',
     )
-    parser.add_argument('output_folder', help='folder name to write tiles to (will be created if does not exist)')
+    parser.add_argument(
+        'output_folder', type=Path, help='folder name to write tiles to (will be created if does not exist)'
+    )
     parser.add_argument(
         '-w',
         '--resize_width',
@@ -214,43 +212,44 @@ def create_parser(prog_name):
     return parser
 
 
-def setup_logging(quiet=False):
+def setup_logging(quiet: bool = False) -> None:
     logging.basicConfig(format='%(levelname)s: %(message)s', stream=sys.stderr)
     LOG.setLevel(logging.WARNING if quiet else logging.INFO)
 
 
-def main():
-    parser = create_parser(sys.argv[0])
-    args = parser.parse_args(sys.argv[1:])
+def main() -> None:
+    parser = create_parser()
+    args = parser.parse_args()
 
     input_path = args.input_file
     zoom_min, zoom_max = args.zoom_level
-    output_folder = args.output_folder
+    output_path = args.output_folder
     resize_width = args.resize_width
     format = args.format
     setup_logging(args.quiet)
 
     # open the image
     try:
-        image = Image.open(input_path)
+        image = Image.open(str(input_path))
         width, height = image.size
         if not power_of(width, 2):
-            LOG.warning('Source image dims should be power of 2! Continuing anyway...')
+            LOG.warning('Source image dims should be power of 2! Continuing anyway...', extra=dict(width=width))
         if width != height:
-            LOG.error('Source image should be square! Quitting...')
+            LOG.error("Source image should be square! Quitting...", extra=dict(width=width, height=height))
             sys.exit(1)
     except UnidentifiedImageError:
-        LOG.error('%s: cannot open image file', input_path)
+        LOG.error("Cannot open image file", extra=dict(input_path=str(input_path)))
         sys.exit(1)
 
-    output_path = Path(output_folder)
-
-    LOG.info('Generating tiles for leaflet.js for zoom levels %d to %d to %s', zoom_min, zoom_max, output_folder)
+    LOG.info(
+        "Generating tiles for leaflet.js for zoom levels",
+        extra=dict(zoom_min=zoom_min, zoom_max=zoom_max, output_path=str(output_path)),
+    )
 
     # if multiple zoom levels, run them all
     for z in range(zoom_min, zoom_max + 1):
-        LOG.info('generate zoom level %d' % z)
-        generate(image, output_path, z, resize_width, format)
+        LOG.info("generate zoom level", extra=dict(zoom_level=z))
+        generate(image=image, outpath=output_path, zoom_level=z, resize_width=resize_width, format=format)
     # that's it!
     LOG.info('FINISHED!')
 

--- a/scripts/gentiles.py
+++ b/scripts/gentiles.py
@@ -224,15 +224,13 @@ def main() -> None:
     input_path = args.input_file
     zoom_min, zoom_max = args.zoom_level
     output_path = args.output_folder
-    resize_width = args.resize_width
-    format = args.format
-    setup_logging(args.quiet)
+    setup_logging(quiet=args.quiet)
 
     # open the image
     try:
         image = Image.open(str(input_path))
         width, height = image.size
-        if not power_of(width, 2):
+        if not power_of(num=width, base=2):
             LOG.warning('Source image dims should be power of 2! Continuing anyway...', extra=dict(width=width))
         if width != height:
             LOG.error("Source image should be square! Quitting...", extra=dict(width=width, height=height))
@@ -249,7 +247,7 @@ def main() -> None:
     # if multiple zoom levels, run them all
     for z in range(zoom_min, zoom_max + 1):
         LOG.info("generate zoom level", extra=dict(zoom_level=z))
-        generate(image=image, outpath=output_path, zoom_level=z, resize_width=resize_width, format=format)
+        generate(image=image, outpath=output_path, zoom_level=z, resize_width=args.resize_width, format=args.format)
     # that's it!
     LOG.info('FINISHED!')
 

--- a/scripts/json2csv.py
+++ b/scripts/json2csv.py
@@ -1,14 +1,18 @@
-import argparse
-import csv
 import json
 import os
 import sys
+from argparse import ArgumentParser
+from csv import DictReader, DictWriter, Sniffer
+from dataclasses import dataclass, field
 from inspect import currentframe, getframeinfo
 from pathlib import Path
+from typing import Any, Optional, Union
+
+type JsonData = Any
 
 
 # Output a warning message
-def warning(warnmsg):
+def warning(warnmsg: str) -> None:
     frameinfo = getframeinfo(currentframe().f_back)
     filename = os.path.basename(frameinfo.filename)
     lineno = frameinfo.lineno
@@ -16,7 +20,7 @@ def warning(warnmsg):
 
 
 # Output an error and terminate
-def error_exit(errmsg, parser=None):
+def error_exit(errmsg: str, parser: Optional[ArgumentParser] = None) -> None:
     frameinfo = getframeinfo(currentframe().f_back)
     filename = os.path.basename(frameinfo.filename)
     lineno = frameinfo.lineno
@@ -26,7 +30,7 @@ def error_exit(errmsg, parser=None):
     if parser:
         parser.print_help()
 
-    sys.exit(-1)
+    sys.exit(1)
 
 
 # We want to convert between CSV and JSON data. CSV is assumed to be a set of
@@ -62,45 +66,46 @@ def error_exit(errmsg, parser=None):
 # }
 
 
+@dataclass
 class CSVData:
-    def __init__(self, fieldnames=[], rowdicts=[]):
-        self.fieldnames = fieldnames
-        self.rowdicts = rowdicts
+    fieldnames: list[str] = field(default_factory=list)
+    rowdicts: list[dict] = field(default_factory=list)
 
 
 # Load a CSV file as a dictionary
-def load_csv_file(path):
-    with open(path, 'r', newline='') as csvfile:
-        dialect = csv.Sniffer().sniff(csvfile.read(1024))
+def load_csv_file(path: Path) -> CSVData:
+    with path.open('r', newline='') as csvfile:
+        dialect = Sniffer().sniff(csvfile.read(1024))
         csvfile.seek(0)
-        reader = csv.DictReader(csvfile, dialect=dialect)
+        reader = DictReader(csvfile, dialect=dialect)
         fieldnames = list(next(reader).keys())
         return CSVData(fieldnames=fieldnames, rowdicts=list(reader))
 
 
-def save_csv_file(csv_data, path):
-    with open(path, 'w', newline='') as csvfile:
-        writer = csv.DictWriter(csvfile, csv_data.fieldnames)
+def save_csv_file(csv_data: CSVData, path: Path) -> None:
+    with path.open('w', newline='') as csvfile:
+        writer = DictWriter(csvfile, csv_data.fieldnames)
         writer.writeheader()
         for rowdict in csv_data.rowdicts:
             writer.writerow(rowdict)
 
 
-def load_json_file(path):
-    return json.load(open(path, 'r', encoding="utf-8-sig"))
+def load_json_file(path: Path) -> JsonData:
+    with path.open('r', encoding="utf-8-sig") as fh:
+        return json.load(fh)
 
 
-def save_json_file(json_data, path):
+def save_json_file(json_data: JsonData, path: Path) -> None:
     path.parent.mkdir(exist_ok=True, parents=True)
-    with open(path, 'w') as file:
+    with path.open('w') as file:
         json.dump(json_data, file, indent=2)
 
 
-def empty_cell(cell):
+def empty_cell(cell: Any) -> bool:
     return cell is None or cell == ''
 
 
-def csv2json(csv_data, keyname=None):
+def csv2json(csv_data: CSVData, keyname: Optional[str] = None) -> JsonData:
     if keyname and keyname in csv_data.fieldnames:
         json = {
             rowdict[keyname]: {k: v for k, v in rowdict.items() if k != keyname and not empty_cell(v)}
@@ -111,7 +116,7 @@ def csv2json(csv_data, keyname=None):
     return json
 
 
-def json2csv(json_data, keyname=None):
+def json2csv(json_data: JsonData, keyname: Optional[str] = None) -> CSVData:
     if isinstance(json_data, dict):
         if not keyname:
             keyname = 'key'
@@ -124,8 +129,8 @@ def json2csv(json_data, keyname=None):
     return CSVData(fieldnames=fieldnames, rowdicts=rowdicts)
 
 
-def main():
-    parser = argparse.ArgumentParser()
+def main() -> None:
+    parser = ArgumentParser()
     parser.add_argument('files', help='file(s) to process (ie *.json or *.csv)')
     parser.add_argument('-i', '--inpath', default='.', help='directory to read files from')
     parser.add_argument('-o', '--outpath', help='directory to write files to (if blank will be set to inpath)')
@@ -149,15 +154,15 @@ def main():
     op = Path(args.outpath)
 
     for infile in ip.glob(args.files):
-        outfile = op.joinpath(infile.with_suffix(outext).relative_to(ip))
+        outfile: Path = op.joinpath(infile.with_suffix(outext).relative_to(ip))
         if input_is_csv:
-            csv_data = load_csv_file(infile)
-            if json_data := csv2json(csv_data, args.keyname):
-                save_json_file(json_data, outfile)
+            csv_data = load_csv_file(path=Path(infile))
+            if json_data := csv2json(csv_data=csv_data, keyname=args.keyname):
+                save_json_file(json_data=json_data, path=outfile)
         else:
-            json_data = load_json_file(infile)
-            if csv_data := json2csv(json_data, args.keyname):
-                save_csv_file(csv_data, outfile)
+            json_data = load_json_file(path=Path(infile))
+            if csv_data := json2csv(json_data=json_data, keyname=args.keyname):
+                save_csv_file(csv_data=csv_data, path=outfile)
 
 
 if __name__ == '__main__':

--- a/scripts/supraland_parser.py
+++ b/scripts/supraland_parser.py
@@ -1,19 +1,26 @@
-import argparse
 import json
-import os
 import re
 import sys
+from argparse import ArgumentParser
 from itertools import groupby
 from math import radians
+from os import environ
 from pathlib import Path
+from typing import Any, Optional
 
 import networkx as nx
 import numpy as np
-import win32com.client
 from libpysal import weights
 from mathutils import Euler, Matrix, Quaternion, Vector
 from PIL import Image
 from sklearn.neighbors import KDTree
+
+try:
+    import win32com.client
+except ModuleNotFoundError:
+    pass
+
+type JsonData = Any
 
 '''
 References to other UE objects the level files and blueprints often use a pair
@@ -180,12 +187,12 @@ So we can normally decode the reference to:
 # "ObjectPath": "/Supraworld/Maps/Supraworld.60177"
 # }
 # Returns 'Supraworld.60177'
-def objectRefStr(p):
+def objectRefStr(p: dict[str, str]) -> str:
     return p['ObjectPath'].split('/')[-1]
 
 
 # Returns ['Supraworld', 60177]
-def objectRef(p):
+def objectRef(p: dict[str, str]) -> list:
     t = objectRefStr(p).split('.')[-2:]
     return [t[0], int(t[1])]
 
@@ -195,13 +202,13 @@ def objectRef(p):
 # "ObjectPath": "/Supraworld/Maps/Supraworld.60177"
 # }
 # Returns 'Supraworld:PersistentLevel.ShopEgg_C_UAID_FC3497C34610BB6D01_1671702339'
-def objectKey(p):
+def objectKey(p: dict[str, str]) -> str:
     return p['Objectpath'].split("'")[1]
 
 
 # Returns a key for an object based on it's area, outer and name. Won't be useful for objects
 # deeper than root or next level in the hierarchy
-def makeObjectKey(area, outer, name):
+def makeObjectKey(area: str, outer: str, name: str) -> str:
     key = area + ':PersistentLevel.'
     if outer != 'PersistentLevel':
         key += outer
@@ -388,7 +395,7 @@ properties = [
 # Unreal mostly uses PascalCase / UpperCamelCase for its naming. This function converts a string of this form
 # to snake case ie all lower case with underscores. It has special handling for flags converting 'bMyVar' to
 # 'is_my_var' and 'MyVar?' to 'my_var_flag'
-def camel_to_snake(s):
+def camel_to_snake(s: str) -> str:
     if s[-1] == '?':
         s = s[:-1] + 'Flag'
     if s.startswith('b'):
@@ -398,12 +405,12 @@ def camel_to_snake(s):
 
 
 # Returns list of numbers in the specified string (ie "a1b98" return ["1", "98"])
-def get_ints(s):
+def get_ints(s: str) -> list[str]:
     return [''.join(group) for key, group in groupby(s, lambda e: e.isdigit()) if key]
 
 
 # Returns last number in the specified string
-def get_last_int(s):
+def get_last_int(s: str) -> str:
     return ints[-1] if (ints := get_ints(s)) else ''
 
 
@@ -411,12 +418,12 @@ def get_last_int(s):
 # Note: we could do this more simply with a regexp but it seems inefficient
 # def get_last_int(s):
 #     return m.group() if (m := re.search('\d+$', s)) else ''
-def get_end_int(s):
+def get_end_int(s: str) -> str:
     return get_ints(s)[-1] if s and s[-1].isdigit() else ''
 
 
 # Return True if this string looks like some kind of enumeration
-def isenum(s):
+def isenum(s: Any) -> bool:
     return (
         isinstance(s, str)
         and '::' in s
@@ -425,7 +432,7 @@ def isenum(s):
 
 
 # Return True if this string looks like an Unreal renamed enumeration
-def isueenum(s):
+def isueenum(s: Any) -> bool:
     return isinstance(s, str) and '::NewEnumerator' in s
 
 
@@ -434,9 +441,9 @@ class UEEnums:
         self.map = {}
         self.types = set()
 
-    def loadenumbp(self, *path):
+    def loadenumbp(self, path: Path):
         # Read the file as a JSON
-        j = load_json_file(*path, quiet=True)
+        j = load_json_file(path=path, quiet=True)
 
         # Check that it is formatted as we expect
         if (
@@ -461,16 +468,16 @@ class UEEnums:
         self.types.add(name)
 
     # If s is an enumeration name we're aware of convert it to the source form
-    def ue2source(self, s, default=None):
+    def ue2source(self, s: str, default: Optional[str] = None) -> str:
         return self.map.get(s, default)
 
     # Returns true if the two enum strings match. First may be a UE renamed enum
     # or a source enum, second should be an untranslated source name
-    def match(self, ue, s):
+    def match(self, ue: str, s: str) -> bool:
         return ue == s or self.ue2source(ue) == s
 
     # If first argument is a UE enum then add it
-    def addueattr(self, ue, s=None):
+    def addueattr(self, ue: str, s: Optional[str] = None) -> None:
         if isueenum(ue):
             if s and s != ue:
                 self.map[ue] = s
@@ -478,9 +485,9 @@ class UEEnums:
 
 
 # Load all enumerations
-def load_all_enumbp(*path_components: str):
+def load_all_enumbp(path: Path) -> UEEnums:
     ueenums = UEEnums()
-    for filename in Path(*path_components).glob('*.json'):
+    for filename in path.glob('*.json'):
         ueenums.loadenumbp(filename)
     return ueenums
 
@@ -501,7 +508,7 @@ def load_all_enumbp(*path_components: str):
 #            break
 #
 #    return metadata
-def get_unreal_version(exepath):
+def get_unreal_version(exepath: Path) -> dict[str, int]:
     uever = {}
     sh = win32com.client.gencache.EnsureDispatch('Shell.Application', 0)
     ns = sh.NameSpace(str(exepath.parent))
@@ -514,7 +521,7 @@ def get_unreal_version(exepath):
 
 
 # Retrieves the steam branch name
-def get_steam_branch(game, path):
+def get_steam_branch(game: str, path: Path) -> str:
     branch = 'public'
 
     # Get path to app manifest from game install path and appid
@@ -522,28 +529,24 @@ def get_steam_branch(game, path):
 
     # If the file exists, open it and read contents
     if manifest.is_file():
-        with open(manifest, 'r') as file:
-            contents = file.read()
-
         # Search for the current user config beta key
-        if match := re.search(r'UserConfig"[\s\S]*?"BetaKey"\s*"([^"]*)', contents):
+        if match := re.search(r'UserConfig"[\s\S]*?"BetaKey"\s*"([^"]*)', manifest.read_text()):
             branch = match.group(1)
 
     return branch
 
 
-def get_swbuild_info(installdir):
-    path = Path(installdir, 'build.vc')
-    with open(path, 'r') as file:
+def get_swbuild_info(installdir: Path) -> dict[str, str]:
+    with installdir.joinpath('build.vc').open('r') as file:
         build = file.readline().rstrip()
         date = file.readline().rstrip()
     return {"build": build, "date": date}
 
 
 # Update Suprawowlrd version information based on steam version installed in 'installdir'
-def update_swversion_info(game, datadir, sourcedir, mapimage):
+def update_swversion_info(game: str, datadir: Path, sourcedir: Path, mapimage: Optional[str] = None) -> None:
 
-    versions = load_json_file(datadir, 'versions.json')
+    versions = load_json_file(path=datadir.joinpath('versions.json'))
 
     # versions JSON looks something like this:
     # {
@@ -555,13 +558,13 @@ def update_swversion_info(game, datadir, sourcedir, mapimage):
     # }
 
     basename = config['sw']['basename']
-    exe_file = Path(list(Path(sourcedir, basename, 'Binaries\\Win64').glob(basename + '-Win64*.exe'))[0])
+    exe_file = Path(list(sourcedir.joinpath(basename, 'Binaries\\Win64').glob(f"{basename}-Win64*.exe"))[0])
 
-    uever = get_unreal_version(exe_file)
+    uever = get_unreal_version(exepath=exe_file)
     versions['sw']['ue'].update(uever)
 
-    gamever = get_swbuild_info(sourcedir)
-    gamever['branch'] = get_steam_branch('sw', sourcedir)
+    gamever = get_swbuild_info(installdir=sourcedir)
+    gamever['branch'] = get_steam_branch(game='sw', path=sourcedir)
     gamever['type'] = exe_file.stem.split('-')[-1]
 
     if mapimage:
@@ -569,22 +572,22 @@ def update_swversion_info(game, datadir, sourcedir, mapimage):
 
     versions['sw']['game'].update(gamever)
 
-    save_json_file(versions, datadir, 'versions.json')
+    save_json_file(data=versions, path=datadir.joinpath('versions.json'))
 
 
 # We presume export.cmd has been used to export a set of map files for the game to
 # a sub-directory of 'sourcedir'. We are going to go through the map and generate
 # information about the
-def preproc_levels(game, datadir, sourcedir):  # noqa: C901 - disable complexity warning
+def preproc_levels(game: str, datadir: Path, sourcedir: Path) -> None:  # noqa: C901 - disable complexity warning
 
     # Load in any enumerations we have found / extracted
-    ueenums = load_all_enumbp(sourcedir, 'enums')
+    ueenums = load_all_enumbp(path=sourcedir.joinpath('enums'))
 
     # Load current gameClasses.json so we know which classes we currently know about for this game
-    game_classes = load_json_file(datadir, 'gameClasses.json')
+    game_classes = load_json_file(path=datadir.joinpath('gameClasses.json'))
 
     # Load the game's PAK file list so we can look up where to find enums
-    gamefilelist = load_filelist(sourcedir)
+    gamefilelist = load_filelist(path=sourcedir)
 
     # Set of blueprint CUE4Parse asset paths for types in gameClasses.json
     # and set of other classes which end in _C
@@ -597,14 +600,14 @@ def preproc_levels(game, datadir, sourcedir):  # noqa: C901 - disable complexity
     propset = {'Root': set(), 'Properties': set(), 'Other': set()}
 
     # Loop through all the level json's we've extracted
-    for filename in Path(sourcedir, 'levels').glob('*.json'):
+    for filename in sourcedir.joinpath('levels').glob('*.json'):
         # Area name is everything between last '\' and the '.json'
         filestr = str(filename)
         area = filestr[filestr.rfind('\\') + 1 : -5]
         area_names.add(area)
 
         # Read the level file in and loop through the outer list of objects)
-        level = load_json_file(filename)
+        level = load_json_file(path=filename)
         level_changed = False
         for obj in level:
             if (
@@ -673,7 +676,7 @@ def preproc_levels(game, datadir, sourcedir):  # noqa: C901 - disable complexity
 
             # Walk all data in the level remembering property names/types
             # Any enum types used and if possible remap enum attributes to source names
-            def gather_properties(obj, setkey):
+            def gather_properties(obj: dict, setkey: str):
                 nonlocal level_changed
 
                 for ref, value in obj.items() if isinstance(obj, dict) else enumerate(obj):
@@ -706,17 +709,19 @@ def preproc_levels(game, datadir, sourcedir):  # noqa: C901 - disable complexity
                         propset[setkey].add(ref + ':' + proptype)
 
                     if isinstance(value, (dict, list)):
-                        gather_properties(value, 'Properties' if ref == 'Properties' else 'Other')
+                        gather_properties(obj=value, setkey='Properties' if ref == 'Properties' else 'Other')
 
-            gather_properties(obj, 'Root')
+            gather_properties(obj=obj, setkey='Root')
 
         # If we changed this level map's enumerations then write it out again
         if level_changed:
-            save_json_file(level, filename)
+            save_json_file(data=level, path=filename)
 
-    save_assetlist(bp_assetlist, gamefilelist, sourcedir, 'bpassetlist.txt')
-    save_assetlist(ueenums.types, gamefilelist, sourcedir, 'enumassetlist.txt', prefer="Enums")
-    save_text_file(sorted(area_names), sourcedir, "areanames.txt")
+    save_assetlist(items=bp_assetlist, filelist=gamefilelist, path=sourcedir.joinpath('bpassetlist.txt'))
+    save_assetlist(
+        items=ueenums.types, filelist=gamefilelist, path=sourcedir.joinpath('enumassetlist.txt'), prefer="Enums"
+    )
+    save_text_file(lines=sorted(area_names), path=sourcedir.joinpath("areanames.txt"))
 
     for k, v in classprops.items():
         classprops[k] = sorted(list(v))
@@ -729,14 +734,14 @@ def preproc_levels(game, datadir, sourcedir):  # noqa: C901 - disable complexity
         "Properties": sorted(list(propset['Properties'])),
         "OtherProps": sorted(list(propset['Other'])),
     }
-    save_json_file(levelprops, sourcedir, 'levelprops.json')
+    save_json_file(data=levelprops, path=sourcedir.joinpath('levelprops.json'))
 
 
 # Load the filelist we have extracted from the specific game which gives the
 # path of all files, so that we can look for files corresponding to enums and
 # structures which don't include the path in the object instance
-def load_filelist(*path, quiet=False):
-    lines = load_text_file(*path, 'gamefilelist.txt', quiet=quiet)
+def load_filelist(path: Path, quiet: Optional[bool] = False):
+    lines = load_text_file(path=path.joinpath('gamefilelist.txt'), quiet=quiet)
     basedict = {}
     for line in lines:
         basename, ext = line.split('/')[-1].split('.')
@@ -754,7 +759,9 @@ def load_filelist(*path, quiet=False):
 # Write an asset list for use by CUE4Parse to select which files to extract
 # from the game PAK file. Blueprints needed for localisation and enums just
 # for understanding data
-def save_assetlist(items, filelist, *path, quiet=False, prefer=None):  # noqa: C901 - disable complexity warning
+def save_assetlist(  # noqa: C901 - disable complexity warning
+    items: list[str], filelist: dict, path: Path, quiet: Optional[bool] = False, prefer: Optional[str] = None
+) -> None:
     lines = []
     basedict = filelist['basedict']
     for item in items:
@@ -776,7 +783,7 @@ def save_assetlist(items, filelist, *path, quiet=False, prefer=None):  # noqa: C
                     if line.lower().endswith(fullname.lower()):
                         lines.append(line)
     lines.sort()
-    save_text_file(lines, *path, quiet=quiet)
+    save_text_file(lines=lines, path=path, quiet=quiet)
 
 
 # The following load/save functions make a path by joining all the varargs
@@ -795,45 +802,40 @@ def save_assetlist(items, filelist, *path, quiet=False, prefer=None):  # noqa: C
 
 
 # Reads a json file and converts it do an object data structure
-def load_json_file(*path_args, quiet=False):
-    path = Path(*path_args)
+def load_json_file(path: Path, quiet: bool = False):
     if not path.exists():
         sys.exit(f'{path} not found, exiting')
     if not quiet:
         print(f'Reading "{path}"...')
-    return json.load(open(path, encoding="utf-8-sig"))
+    with path.open('r', encoding="utf-8-sig") as fh:
+        return json.load(fh)
 
 
 # Converts object to JSON format and writes it to the specified location
-def save_json_file(object, *path, quiet=False):
-    path = os.path.join(*path[0:-1], path[-1])
-    with open(path, 'w') as file:
+def save_json_file(data: JsonData, path: Path, quiet: bool = False) -> None:
+    with path.open('w') as file:
         if not quiet:
             print(f'Writing "{path}"...')
-        json.dump(object, file, indent=2)
+        json.dump(data, file, indent=2)
 
 
 # Load a text file into a string list with an entry for each line
 # Removes newlines from end of each line
-def load_text_file(*path, quiet=False):
-    path = os.path.join(*path[0:-1], path[-1])
-    if not os.path.exists(path):
+def load_text_file(path: Path, quiet: Optional[bool] = False) -> list[str]:
+    if not path.exists():
         sys.exit(f'{path} not found, exiting')
     if not quiet:
         print(f'Reading "{path}"...')
-    with open(path) as file:
-        return file.read().splitlines()
+    return path.read_text().splitlines()
 
 
 # Overwrite file with each string in lines list adding newline to each
-def save_text_file(lines, *path, quiet=False):
-    path = os.path.join(*path[0:-1], path[-1])
-    with open(path, 'w') as file:
-        if not quiet:
-            print(f'Writing "{path}"...')
-        with open(path, 'w') as file:
-            for line in lines:
-                file.write(line + '\n')
+def save_text_file(lines: list[str], path: Path, quiet: Optional[bool] = False) -> None:
+    if not quiet:
+        print(f'Writing "{path}"...')
+    with path.open('w') as file:
+        for line in lines:
+            file.write(line + '\n')
 
 
 sw_blueprint_keys_used = [
@@ -876,13 +878,13 @@ sw_blueprint_keys_used = [
 
 
 # Read properties from the blueprints for the specified set of property keys
-def load_blueprint_keys(sourcedir: str, def_keys: list[str], type_keys: dict[str, str] = None):
+def load_blueprint_keys(sourcedir: Path, def_keys: list[str], type_keys: dict[str, str] = None):
     if type_keys is None:
         type_keys = {}
-    path = Path(sourcedir, 'bp')
+    path = sourcedir.joinpath('bp')
     bp_defaults = {}
     for filename in path.glob('*.json'):
-        json = load_json_file(str(filename), quiet=True)
+        json = load_json_file(path=filename, quiet=True)
         otype = filename.stem + '_C'
         bp_defaults[otype] = {}
         for obj in json:
@@ -896,12 +898,12 @@ def load_blueprint_keys(sourcedir: str, def_keys: list[str], type_keys: dict[str
 
 
 # Load in a PNG file containing RGB values
-def load_ea_fog(*path):
-    path = os.path.join(*path, 'mapimg', ea_fogfile)
-    if not os.path.exists(path):
+def load_ea_fog(path: Path) -> Optional[Image]:
+    path = path.joinpath('mapimg', ea_fogfile)
+    if not path.exists():
         print(f'Warning: Failed to load fog png ({path})')
         return None
-    with Image.open(path) as im:
+    with Image.open(str(path)) as im:
         global ea_fog_width, ea_fog_height, ea_fog_pixels
         ea_fog_width = im.width
         ea_fog_height = im.height
@@ -978,7 +980,7 @@ def getXYZ(v):
     return dict(x=v.x, y=v.y, z=v.z)
 
 
-def export_sw_markers(game, datadir, sourcedir):  # noqa: C901 - disable complexity warning
+def export_sw_markers(game: str, datadir: Path, sourcedir: Path):  # noqa: C901 - disable complexity warning
     maps = {}  # dictionary from map name to json data list
     toyeggs = {}  # Collected chocolate eggs
     staticmeshes = {}  # dictionary from outer name to static mesh name
@@ -988,15 +990,17 @@ def export_sw_markers(game, datadir, sourcedir):  # noqa: C901 - disable complex
     data = []  # Output marker data
 
     # Load in any enumerations we have found / extracted
-    ueenums = load_all_enumbp(sourcedir, 'enums')
+    ueenums = load_all_enumbp(path=sourcedir.joinpath('enums'))
 
-    bp_defaults = load_blueprint_keys(sourcedir, sw_blueprint_keys_used, {"InvFrag_SupraworldShopItem": ["Cost"]})
+    bp_defaults = load_blueprint_keys(
+        sourcedir=sourcedir, def_keys=sw_blueprint_keys_used, type_keys={"InvFrag_SupraworldShopItem": ["Cost"]}
+    )
 
     # Phase 1: Read all the map json files in and build a look up table for references
     # Also get any area/map file matrices (for streaming levels)
     for area in config[game]['maps']:
         # Store the map data
-        maps[area] = load_json_file(sourcedir, 'levels', area + '.json')
+        maps[area] = load_json_file(path=sourcedir.joinpath('levels', f"{area}.json"))
 
         # Go through all objects in the map data and store lookups for later
         for oidx, o in enumerate(maps[area]):
@@ -1046,9 +1050,9 @@ def export_sw_markers(game, datadir, sourcedir):  # noqa: C901 - disable complex
                     Matrix.Translation(getVec(t.get('Translation'))) @ getQuat(t.get('Rotation')).to_matrix().to_4x4()
                 )
 
-    game_classes = load_json_file(datadir, 'gameClasses.json')
+    game_classes = load_json_file(path=datadir.joinpath('gameClasses.json'))
 
-    load_ea_fog(sourcedir)
+    load_ea_fog(path=sourcedir)
 
     # Phase 2: Go through all the objects which have types we're interested in
     for area in maps:
@@ -1269,16 +1273,15 @@ def export_sw_markers(game, datadir, sourcedir):  # noqa: C901 - disable complex
             if comment:
                 data[-1]['comment'] = comment
 
-    save_json_file(data, datadir, f'markers.{game}.json')
+    save_json_file(data=data, path=datadir.joinpath(f'markers.{game}.json'))
     print("Done")
 
 
-def export_class_loc(game, datadir, sourcedir):  # noqa: C901 - disable complexity warning
-    game_classes = load_json_file(datadir, 'gameClasses.json')
+def export_class_loc(game: str, datadir: Path, sourcedir: Path) -> None:  # noqa: C901 - disable complexity warning
+    game_classes = load_json_file(path=datadir.joinpath('gameClasses.json'))
 
     for game in ['sl', 'siu']:
-        path = os.path.join(sourcedir, 'blueprints.' + game + '.json')
-        blueprints = json.load(open(path, 'r'))
+        blueprints = load_json_file(path=sourcedir.joinpath(f'blueprints.{game}.json'))
 
         def optKey(game_class, cls, k, v):
             if v:
@@ -1313,17 +1316,17 @@ def export_class_loc(game, datadir, sourcedir):  # noqa: C901 - disable complexi
                                         game_classes, gcls, 'description_key', props['UpgradeDescription'].get('Key')
                                     )
 
-    save_json_file(datadir, 'gameClasses.json')
+    save_json_file(data=game_classes, path=datadir.joinpath('gameClasses.json'))
 
 
-def export_loc_files(game, datadir, sourcedir):  # noqa: C901 - disable complexity warning
+def export_loc_files(game: str, datadir: Path, sourcedir: Path) -> None:  # noqa: C901 - disable complexity warning
     # Merge custom-loc.json into gameClasses.json
     print('Merging custom-loc.json into gameClasses.json...')
-    classes = load_json_file(datadir, 'gameClasses.json')
-    customLoc = load_json_file(datadir, 'custom-loc.json')
+    classes = load_json_file(path=datadir.joinpath('gameClasses.json'))
+    customLoc = load_json_file(path=datadir.joinpath('custom-loc.json'))
     for c, d in customLoc.items():
         classes[c] = classes[c] | d
-    save_json_file(classes, datadir, 'gameClasses.json')
+    save_json_file(data=classes, path=datadir.joinpath('gameClasses.json'))
 
     # Make a list of the keys that are referenced in the various files
     keys = set()
@@ -1340,9 +1343,9 @@ def export_loc_files(game, datadir, sourcedir):  # noqa: C901 - disable complexi
     ]
     print('Reading files to determine loc keys required...')
     for fn in key_files:
-        path = Path(datadir, fn)
+        path = datadir.joinpath(fn)
         if path.exists():
-            data = load_json_file(path)
+            data = load_json_file(path=path)
             for entry in data if type(data) is list else data.values():
                 for k in ['friendly_key', 'name_key', 'description_key', 'key']:
                     if entry.get(k):
@@ -1372,8 +1375,7 @@ def export_loc_files(game, datadir, sourcedir):  # noqa: C901 - disable complexi
     for loc in loc_names:
         newlocstr = {}
         for game in ['sl', 'siu']:
-            fn = os.path.join(sourcedir, f'LOC/{game}/{loc}/Game.json')
-            locstr = json.load(open(fn, 'r', encoding='utf-8'))
+            locstr = load_json_file(path=sourcedir.joinpath(f'LOC/{game}/{loc}/Game.json'))
             for k in locstr.keys():
                 if k in keys:
                     # if newlocstr.get(k) and newlocstr[k] != locstr[k]:
@@ -1381,10 +1383,10 @@ def export_loc_files(game, datadir, sourcedir):  # noqa: C901 - disable complexi
                     #    print(f'SIU {locstr[k]}')
                     newlocstr[k] = locstr[k]
         print(f'Writing to ../public/data/loc/locstr-{loc}.json')
-        save_json_file(newlocstr, datadir, '/loc/locstr-{loc}.json')
+        save_json_file(data=newlocstr, path=datadir.joinpath(f'loc/locstr-{loc}.json'))
 
 
-def export_markers(game, datadir, sourcedir):  # noqa: C901 - disable complexity warning
+def export_markers(game: str, datadir: Path, sourcedir: Path) -> None:  # noqa: C901 - disable complexity warning
     maps = {}  # dictionary from map name to json data list
     area_mtx = {}  # Transform for each area map geometry
     data = []  # Output marker data
@@ -1394,13 +1396,13 @@ def export_markers(game, datadir, sourcedir):  # noqa: C901 - disable complexity
 
     data_lookup = {}
 
-    game_classes = load_json_file(datadir, 'gameClasses.json')
+    game_classes = load_json_file(path=datadir.joinpath('gameClasses.json'))
 
     # Phase 1: Read all the map json files in and build a look up table for references
     # Also get any area/map file matrices (for streaming levels)
     for area in config[game]['maps']:
         # Store the map data
-        maps[area] = load_json_file(sourcedir, 'levels', area + '.json')
+        maps[area] = load_json_file(path=sourcedir.joinpath('levels', f"{area}.json"))
 
         # Go through all objects in the map data and store lookups for later
         for oidx, o in enumerate(maps[area]):
@@ -1519,10 +1521,10 @@ def export_markers(game, datadir, sourcedir):  # noqa: C901 - disable complexity
     calc_pipes(data)
 
     # Merge in custom and legacy data, clean the properties and remove ones we don't need
-    cleanup_objects(game, sourcedir, data_lookup, data)
+    cleanup_objects(game=game, sourcedir=sourcedir, data_lookup=data_lookup, data=data)
 
     print('collected %d markers' % (len(data)))
-    save_json_file(data, datadir, 'markers.' + game + '.json')
+    save_json_file(data=data, path=datadir.joinpath(f'markers.{game}.json'))
 
 
 def calc_pipes(data):
@@ -1830,7 +1832,9 @@ exported_properties = [
 # lookup is a dictionary from area:name to objects
 # data is an array of the same objects
 # each object is a dictionary of k,v pairs
-def cleanup_objects(game, sourcedir, data_lookup, data):  # noqa: C901 - disable complexity warning
+def cleanup_objects(  # noqa: C901 - disable complexity warning
+    game: str, sourcedir: Path, data_lookup: dict, data: dict
+) -> None:
     def get_xyz(o):
         return dict(x=o['lng'], y=o['lat'], z=o['alt'])
 
@@ -1838,7 +1842,7 @@ def cleanup_objects(game, sourcedir, data_lookup, data):  # noqa: C901 - disable
         return get_xyz(data_lookup[o['nearest_cap']]) if 'nearest_cap' in o else get_xyz(o)
 
     # Read the set of pads and pipes we found save data for
-    savedpadpipes = read_savedpadpipes(game, sourcedir)
+    savedpadpipes = read_savedpadpipes(game=game, sourcedir=sourcedir)
 
     # Walk the remaining instances and fix up entries
     for o in data:
@@ -1946,7 +1950,7 @@ def cleanup_objects(game, sourcedir, data_lookup, data):  # noqa: C901 - disable
 
 # Goes through all the non-rotating coins and looks for groups of more than 3 to combine into coinstacks
 # Adds the new stack objects to our collection and removes the original coins
-def create_coinstacks(data_lookup, data):
+def create_coinstacks(data_lookup, data) -> None:
 
     threshold = 400
 
@@ -2010,7 +2014,7 @@ def create_coinstacks(data_lookup, data):
 
 
 # Somewhat hacky code to convert class name to a more friendly name
-def friendly_name(cls):
+def friendly_name(cls: str):
     n = re.sub(r'(?:_C$)|(?:^BP_)|(?:Purchase)|(?:Buy)|_|DLC2|DLC|New', '', cls)
     n = n.replace('pct', '%')
     n = re.sub(r'x([0-9])', r'*\1', n)
@@ -2026,24 +2030,23 @@ def friendly_name(cls):
 
 # This file is generated using hard coded information and info from a save
 # file. It is generated by dumpsavefile.js
-def read_savedpadpipes(game, sourcedir):
-
-    path = Path(sourcedir, f'savedpadpipes.{game}.json')
+def read_savedpadpipes(game: str, sourcedir: Path) -> dict[str, list]:
+    path = sourcedir.joinpath(f'savedpadpipes.{game}.json')
 
     # Open and read the whole js file if it exists
     if path.exists():
         print('Reading "' + path + '"...')
-        return json.load(open(path, 'r', encoding='utf-8'))
+        return load_json_file(path=path)
 
     print(f'Warning: {path} not found, skipping')
     return {'pipes': [], 'pads': []}
 
 
-def main():
-    parser = argparse.ArgumentParser()
+def main() -> None:
+    parser = ArgumentParser()
 
     # game, data and source directory used by all commands
-    parser.add_argument('-g', '--game', default='sw', help='game name (sl, slc, siu, sw)')
+    parser.add_argument('-g', '--game', choices=['sl', 'slc', 'siu', 'sw'], default='sw', help='game name')
     parser.add_argument('-d', '--data', default='..\\public\\data', help='output json data directory')
     parser.add_argument('-s', '--source', default='..\\source', help='location of game data needed by command')
 
@@ -2064,22 +2067,26 @@ def main():
     if sourcedir == '..\\source':
         sourcedir += '\\' + (args.game if args.game != 'slc' else 'sl')
 
+    datadir = Path(args.data)
+    sourcedir = Path(sourcedir)
     if args.preproc:
-        preproc_levels(args.game, args.data, sourcedir)
+        preproc_levels(game=args.game, datadir=datadir, sourcedir=sourcedir)
     elif args.markers:
         if args.game == 'sw':
-            export_sw_markers(args.game, args.data, sourcedir)
+            export_sw_markers(game=args.game, datadir=datadir, sourcedir=sourcedir)
         else:
-            export_markers(args.game, args.data, sourcedir)
+            export_markers(game=args.game, datadir=datadir, sourcedir=sourcedir)
     elif args.version:
         if args.game == 'sw':
+            if not args.source:
+                sourcedir = Path(environ.get('SWROOT'))
             update_swversion_info(
-                args.game, args.data, args.source or os.environ.get('SWROOT'), os.environ.get('SWMAPIMAGE')
+                game=args.game, datadir=datadir, sourcedir=sourcedir, mapimage=environ.get('SWMAPIMAGE')
             )
     elif args.blueprints:
-        export_class_loc(args.game, args.data, sourcedir)
+        export_class_loc(game=args.game, datadir=datadir, sourcedir=sourcedir)
     elif args.loc:
-        export_loc_files(args.game, args.data, sourcedir)
+        export_loc_files(game=args.game, datadir=datadir, sourcedir=sourcedir)
     else:
         parser.print_help()
 

--- a/scripts/supraland_parser.py
+++ b/scripts/supraland_parser.py
@@ -9,11 +9,11 @@ from pathlib import Path
 
 import networkx as nx
 import numpy as np
+import win32com.client
 from libpysal import weights
 from mathutils import Euler, Matrix, Quaternion, Vector
 from PIL import Image
 from sklearn.neighbors import KDTree
-import win32com.client
 
 '''
 References to other UE objects the level files and blueprints often use a pair
@@ -221,7 +221,7 @@ config = {
         'pathmap': {
             'Game': 'Supraland/Content',
         },
-        'maps': ['Map']
+        'maps': ['Map'],
     },
     'slc': {
         'appid': '813630',
@@ -229,7 +229,7 @@ config = {
         'pathmap': {
             'Game': 'Supraland/Content',
         },
-        'maps': ['Crash']
+        'maps': ['Crash'],
     },
     'siu': {
         'appid': '1522870',
@@ -249,7 +249,7 @@ config = {
             'DLC2_RainbowTown',
             'DLC2_SecretLavaArea',
             'DLC2_Splash',
-        ]
+        ],
     },
     'sw': {
         'appid': '1869291',
@@ -260,8 +260,8 @@ config = {
             'SupraAssets': 'Supraworld/Plugins/Supra/SupraAssets/Content/',
             'SupraCore': 'Supraworld/Plugins/Supra/SupraCore/Content/',
         },
-        'maps': ['Supraworld']
-    }
+        'maps': ['Supraworld'],
+    },
 }
 
 
@@ -320,13 +320,9 @@ travel_types = [
 # Override Material Variants
 material_types = ["Nailscrew_C", "PuzzleCloud_C"]
 
-tracked_staticmeshes = [
-    'Poker_Chip_1'
-]
+tracked_staticmeshes = ['Poker_Chip_1']
 
-staticmesh2variant = {
-    'Poker_Chip_1': 'red'
-}
+staticmesh2variant = {'Poker_Chip_1': 'red'}
 
 material2variant = {
     'Metal_Base_Golden': 'gold',
@@ -522,7 +518,7 @@ def get_steam_branch(game, path):
     branch = 'public'
 
     # Get path to app manifest from game install path and appid
-    manifest = Path(path[0:path.find('common')] + 'appmanifest_' + config[game]['appid'] + '.acf')
+    manifest = Path(path[0 : path.find('common')] + 'appmanifest_' + config[game]['appid'] + '.acf')
 
     # If the file exists, open it and read contents
     if manifest.is_file():
@@ -881,7 +877,8 @@ sw_blueprint_keys_used = [
 
 # Read properties from the blueprints for the specified set of property keys
 def load_blueprint_keys(sourcedir: str, def_keys: list[str], type_keys: dict[str, str] = None):
-    if type_keys is None: type_keys = {}
+    if type_keys is None:
+        type_keys = {}
     path = Path(sourcedir, 'bp')
     bp_defaults = {}
     for filename in path.glob('*.json'):
@@ -916,10 +913,11 @@ def in_earlyaccess(otype, p, pos):  # noqa: C901 - disable complexity warning
         return True
 
     # If it has a progression and it's not in released content then reject
-    if ((proggroup := p.get('ProgressionGroup', {}).get('TagName'))
-            and proggroup != "None"
-            and not any(proggroup.endswith(s) for s in ea_proggroups)
-        ):
+    if (
+        (proggroup := p.get('ProgressionGroup', {}).get('TagName'))
+        and proggroup != "None"
+        and not any(proggroup.endswith(s) for s in ea_proggroups)
+    ):
         return False
 
     # If it has an area that's not
@@ -983,7 +981,7 @@ def getXYZ(v):
 def export_sw_markers(game, datadir, sourcedir):  # noqa: C901 - disable complexity warning
     maps = {}  # dictionary from map name to json data list
     toyeggs = {}  # Collected chocolate eggs
-    staticmeshes = {} # dictionary from outer name to static mesh name
+    staticmeshes = {}  # dictionary from outer name to static mesh name
     meshmats = {}  # dictionary from outer name to mesh material variant
     targets = {}  # dictionary from outer name to target positions
     area_mtx = {}  # Transform for each area map geometry
@@ -1009,23 +1007,22 @@ def export_sw_markers(game, datadir, sourcedir):  # noqa: C901 - disable complex
 
             # Keep list of static meshes by parent/outer
             if otype == 'StaticMeshComponent':
-                if (
-                        (sm := p.get('StaticMesh', {}).get('ObjectName'))
-                        and (sm := sm.split("'")[-2]) in tracked_staticmeshes
-                    ):
+                if (sm := p.get('StaticMesh', {}).get('ObjectName')) and (
+                    sm := sm.split("'")[-2]
+                ) in tracked_staticmeshes:
                     staticmeshes[outer] = sm
-                    if (sm in staticmesh2variant):
+                    if sm in staticmesh2variant:
                         meshmats[outer] = staticmesh2variant[sm]
 
-                if (oms := p.get('OverrideMaterials')):
+                if oms := p.get('OverrideMaterials'):
                     for om in oms:
                         if (
-                                om
-                                and (v := om.get('ObjectName'))
-                                and (v := material2variant.get(v.split("'")[-2].split('.')[-1]))
-                            ):
+                            om
+                            and (v := om.get('ObjectName'))
+                            and (v := material2variant.get(v.split("'")[-2].split('.')[-1]))
+                        ):
                             meshmats[outer] = v
-    
+
             # Keep list of Chocolate Egg interior objects
             if otype == 'ChocolateEgg_C' and (v := p.get('ToyEgg')):
                 toyeggs[objectRefStr(v)] = o
@@ -1107,8 +1104,7 @@ def export_sw_markers(game, datadir, sourcedir):  # noqa: C901 - disable complex
                 continue
 
             # Convert poker chip static meshes to custom Poker Chip class
-            if ((v := staticmeshes.get(oname))
-                    and v == 'Poker_Chip_1'):
+            if (v := staticmeshes.get(oname)) and v == 'Poker_Chip_1':
                 otype = '_PokerChip_C'
 
             # Add the standard data to the object
@@ -1200,8 +1196,12 @@ def export_sw_markers(game, datadir, sourcedir):  # noqa: C901 - disable complex
                 spawns = '_LootPool_C'
 
             # Cost
-            if ((v := bp_defaults.get(spawns, {}).get('Cost'))
-                    and otype in ['ShopItemSpawner_C', 'ShopEgg_C', 'ChocolateEgg_C', 'ShopSlot_C']):
+            if (v := bp_defaults.get(spawns, {}).get('Cost')) and otype in [
+                'ShopItemSpawner_C',
+                'ShopEgg_C',
+                'ChocolateEgg_C',
+                'ShopSlot_C',
+            ]:
                 data[-1]['cost'] = v
 
             # These classes just spawn stuff so we change the type to what it spawns
@@ -1221,7 +1221,7 @@ def export_sw_markers(game, datadir, sourcedir):  # noqa: C901 - disable complex
             if (v := coin_defaults.get(otype)) or (v := coin_defaults.get(spawns)):
                 coins = v
             if (v := p.get('Value')) and v.startswith('CoinValue::'):  # RealCoinPickup_C/5Cent_C
-                coins = int(get_end_int(ueenums.ue2source(v,v)))
+                coins = int(get_end_int(ueenums.ue2source(v, v)))
             if v := p.get('CoinPool'):  # Gumball_Machine_C
                 coins = v
             if coins:
@@ -2050,8 +2050,12 @@ def main():
     # these are the core operations
     parser.add_argument('-p', '--preproc', action='store_true', help='preprocess level files to gather ')
     parser.add_argument('-m', '--markers', action='store_true', help='export markers as json (need json levels)')
-    parser.add_argument('-v', '--version', action='store_true', help='update version information (set source to install directory)')
-    parser.add_argument('-b', '--blueprints', action='store_true', help='read loc from blueprints and export to gameClasses')
+    parser.add_argument(
+        '-v', '--version', action='store_true', help='update version information (set source to install directory)'
+    )
+    parser.add_argument(
+        '-b', '--blueprints', action='store_true', help='read loc from blueprints and export to gameClasses'
+    )
     parser.add_argument('-o', '--loc', action='store_true', help='extract required loc strings for game')
     args = parser.parse_args()
 
@@ -2069,7 +2073,9 @@ def main():
             export_markers(args.game, args.data, sourcedir)
     elif args.version:
         if args.game == 'sw':
-            update_swversion_info(args.game, args.data, args.source or os.environ.get('SWROOT'), os.environ.get('SWMAPIMAGE'))
+            update_swversion_info(
+                args.game, args.data, args.source or os.environ.get('SWROOT'), os.environ.get('SWMAPIMAGE')
+            )
     elif args.blueprints:
         export_class_loc(args.game, args.data, sourcedir)
     elif args.loc:

--- a/uv.lock
+++ b/uv.lock
@@ -75,25 +75,25 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.4.3"
+version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/16/4b272700dea44c1d2e8ca963ebb3c684efe22b3eba8cfa31c5fdb60de707/build-1.4.3.tar.gz", hash = "sha256:5aa4231ae0e807efdf1fd0623e07366eca2ab215921345a2e38acdd5d0fa0a74", size = 89314, upload-time = "2026-04-10T21:25:40.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/ec/bf5ae0a7e5ab57abe8aabdd0759c971883895d1a20c49ae99f8146840c3c/build-1.4.4.tar.gz", hash = "sha256:f832ae053061f3fb524af812dc94b8b84bac6880cd587630e3b5d91a6a9c1703", size = 89220, upload-time = "2026-04-22T20:53:44.807Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/30/f169e1d8b2071beaf8b97088787e30662b1d8fb82f8c0941d14678c0cbf1/build-1.4.3-py3-none-any.whl", hash = "sha256:1bc22b19b383303de8f2c8554c9a32894a58d3f185fe3756b0b20d255bee9a38", size = 26171, upload-time = "2026-04-10T21:25:39.671Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/88/6764e7a109dd84294850741501145da90d13cdeac9d4e614929464a37420/build-1.4.4-py3-none-any.whl", hash = "sha256:8c3f48a6090b39edec1a273d2d57949aaf13723b01e02f9d518396887519f64d", size = 25921, upload-time = "2026-04-22T20:53:43.251Z" },
 ]
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
 ]
 
 [[package]]
@@ -194,14 +194,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -227,11 +227,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.28.0"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/17/6e8890271880903e3538660a21d63a6c1fea969ac71d0d6b608b78727fa9/filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6", size = 56474, upload-time = "2026-04-14T22:54:33.625Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db", size = 39189, upload-time = "2026-04-14T22:54:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -276,11 +276,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -566,11 +566,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.0.4"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
 ]
 
 [[package]]
@@ -1048,7 +1048,7 @@ dev = [
     { name = "networkx" },
     { name = "numpy" },
     { name = "pillow" },
-    { name = "pywin32" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "scikit-learn" },
 ]
 
@@ -1065,7 +1065,7 @@ dev = [
     { name = "networkx", specifier = ">=3.6.1" },
     { name = "numpy", specifier = ">=2.4.4" },
     { name = "pillow", specifier = ">=12.2.0" },
-    { name = "pywin32", specifier = ">=311" },
+    { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=311" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
 ]
 
@@ -1107,12 +1107,12 @@ wheels = [
 
 [[package]]
 name = "wheel"
-version = "0.46.3"
+version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/24/a2eb353a6edac9a0303977c4cb048134959dd2a51b48a269dfc9dde00c8a/wheel-0.46.3.tar.gz", hash = "sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803", size = 60605, upload-time = "2026-01-22T12:39:49.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/62/75f18a0f03b4219c456652c7780e4d749b929eb605c098ce3a5b6b6bc081/wheel-0.47.0.tar.gz", hash = "sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3", size = 63854, upload-time = "2026-04-22T15:51:27.727Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/22/b76d483683216dde3d67cba61fb2444be8d5be289bf628c13fc0fd90e5f9/wheel-0.46.3-py3-none-any.whl", hash = "sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d", size = 30557, upload-time = "2026-01-22T12:39:48.099Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1b/9e33c09813d65e248f7f773119148a612516a4bea93e9c6f545f78455b7c/wheel-0.47.0-py3-none-any.whl", hash = "sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced", size = 32218, upload-time = "2026-04-22T15:51:26.296Z" },
 ]


### PR DESCRIPTION
* Refactors the Python files to use named parameters and type hints.
* Converts all use of paths to `Path` objects.
* Modernize code to use `pathlib` methods, instead of older-style `os.path.` calls.
* Update `pyproject.toml` so that the `pywin32` dependency is only installed on Windows.

**Caveat**: This code has not been fully tested!
