### PR TITLE
Custom POI

### DIFF
--- a/public/data/custom-markers.sw.json
+++ b/public/data/custom-markers.sw.json
@@ -18,5 +18,14 @@
     "name": "PresentBox_C_UAID_7085C2B20F0ED96602_1438589775",
     "area": "Supraworld",
     "delete": "saved object removed in update"
+  },
+  {
+    "name": "_CustomPOI_C_01",
+    "type": "_CustomPOI_C",
+    "area": "Supraworld",
+    "lat": -4340,
+    "lng": 2321,
+    "alt": 323,
+    "friendly": "Floor Town"
   }
 ]

--- a/public/data/gameClasses.json
+++ b/public/data/gameClasses.json
@@ -287,6 +287,7 @@
   "SupraworldPlayerStart_C"         : { "friendly": "Player Start",        "icon": "playerstart",        "layer": "poi",           "nospoiler": null,          "games": ["sw"], "setfound": false                },
   "_PokerChip_C"                    : { "friendly": "Poker Chip",          "icon": "pokerchip:vx0.75",        "layer": "poi",           "nospoiler": null,          "games": ["sw"]                                   },
   "_SWPlayerPosition"               : { "friendly": "Player Position",     "icon": "swplayerpos",        "layer": "_map",          "nospoiler": null,          "games": ["sw"]                                   },
+  "_CustomPOI_C"                    : { "friendly": "Point of Interest",   "icon": "swmisc",             "layer": "poi",           "nospoiler": null,          "games": ["sw"], "setfound": false                },
 
   "ChocolateEgg_C"                  : { "friendly": "Chocolate Egg",       "icon": "chocolate_egg",      "layer": "swcollectable", "nospoiler": "swnospoiler", "games": ["sw"]                                   },
   "ShopEgg_C"                       : { "friendly": "Egg",                 "icon": "egg",                "layer": "swcollectable", "nospoiler": "swnospoiler", "games": ["sw"]                                   },

--- a/web_src/devBuildMode.js
+++ b/web_src/devBuildMode.js
@@ -24,6 +24,7 @@ export function setBuildMode(newBuildMode) {
   Settings.globalSetDefault('buildMode', false);
   Settings.global.buildMode = newBuildMode;
   Settings.commit();
+  MapObject.updateTitles();
 }
 
 export function updateBuildModeValue(event) {

--- a/web_src/icons.js
+++ b/web_src/icons.js
@@ -110,9 +110,9 @@ export class Icons {
     const size = 48; // Size to render icons
     const outlineSize = size * 0.976; // Scale adjustment between shadow and background
     const pinIconSize = size * 0.5; // Size to draw the FA icon on a pin marker
-    const pinCentreOfs = pinIconSize * -0.25; // Y offset from centre of icon to centre for a pin
+    const pinCentreYOffset = pinIconSize * -0.25; // Y offset from centre of icon to centre for a pin
     const ptIconSize = size * 0.7; // Size to draw the FA icon on a point marker
-    const ptCentreOfs = ptIconSize * -0.2; // Y offset from centre of icon to centre for a pin
+    const ptCentreYOffset = ptIconSize * -0.2; // Y offset from centre of icon to centre for a pin
 
     // We're going to draw the icon to a canvas
     const canvas = document.createElement('canvas');
@@ -155,7 +155,7 @@ export class Icons {
     drawFAIcon('fas', isPin ? faPin : faPoint, bg, outlineSize);
 
     if (style == 'fapng' || style == 'fasvg')
-      drawImageIcon(iconName, size, isPin ? pinIconSize : ptIconSize, isPin ? pinCentreOfs : ptCentreOfs);
+      drawImageIcon(iconName, size, isPin ? pinIconSize : ptIconSize, isPin ? pinCentreYOffset : ptCentreYOffset);
     else
       drawFAIcon(
         style,

--- a/web_src/icons.js
+++ b/web_src/icons.js
@@ -109,9 +109,10 @@ export class Icons {
     const faDefault = 'question-circle'; // FA icon used if asked for unknown icon
     const size = 48; // Size to render icons
     const outlineSize = size * 0.976; // Scale adjustment between shadow and background
-    const pinCentreOfs = size * -0.125; // Y offset from centre of icon to centre for a pin
     const pinIconSize = size * 0.5; // Size to draw the FA icon on a pin marker
-    const ptIconSize = size * 0.55; // Size to draw the FA icon on a point marker
+    const pinCentreOfs = pinIconSize * -0.25; // Y offset from centre of icon to centre for a pin
+    const ptIconSize = size * 0.7; // Size to draw the FA icon on a point marker
+    const ptCentreOfs = ptIconSize * -0.2; // Y offset from centre of icon to centre for a pin
 
     // We're going to draw the icon to a canvas
     const canvas = document.createElement('canvas');
@@ -154,7 +155,7 @@ export class Icons {
     drawFAIcon('fas', isPin ? faPin : faPoint, bg, outlineSize);
 
     if (style == 'fapng' || style == 'fasvg')
-      drawImageIcon(iconName, size, isPin ? pinIconSize : ptIconSize, isPin ? pinCentreOfs : 0);
+      drawImageIcon(iconName, size, isPin ? pinIconSize : ptIconSize, isPin ? pinCentreOfs : ptCentreOfs);
     else
       drawFAIcon(
         style,

--- a/web_src/mapObject.jsx
+++ b/web_src/mapObject.jsx
@@ -65,6 +65,7 @@ import { PinContent } from './PinContent.jsx';
 //
 //  loadObjects                - called to load/construct/init all MapObjects from the various Json files
 //  initObjects                - called after loadObjects to add all the markers to the map
+//  updateTitles               - call if the state of the system has changed to refresh all the marker titles
 //
 //  addObjectFromJson          - called by load to instantiate or merge a MapObject
 //  resetAll                   - called to reset us to initial state (also resets SaveFileSystem)
@@ -499,6 +500,30 @@ export class MapObject {
     delete window.mapObjectFound;
   }
 
+  // Refresh the titles for all markers
+  static updateTitles() {
+    // This could be done by calling map.eachLayer and checking if layer is a marker 
+    for(const mapObject of Object.values(this._mapObjects)) {
+      const title = mapObject.getTooltipText(Settings.mapId);
+      if(mapObject.primeMarker)
+        mapObject.primeMarker.options.title = title;
+      if(mapObject.groupMarker)
+        mapObject.groupMarker.options.title = title;
+    }
+  }
+
+  // Move player position marker / altitude reference to specified object
+  static movePlayerPosition(mapObject) {
+    const p = MapObject._mapObjects.PlayerPosition;
+    if(p){
+      p.o.lat = mapObject.o.lat;
+      p.o.lng = mapObject.o.lng;
+      p.o.alt = mapObject.o.alt;
+      p.setLatLng({lat: p.o.lat, lng: p.o.lng});
+      MapObject.updateTitles();
+    }
+  }
+
   static get(id) {
     return this._mapObjects[id];
   }
@@ -581,7 +606,10 @@ class MapPlayerPosition extends MapObject {
     if (!data) {
       Object.assign(this.o, MapObject._playerStartPosition);
       this.setLatLng({ lat: this.o.lat, lng: this.o.lng });
-    } else {
+
+      // Mouse over / search titles which include the relative altitude may have changed
+      MapObject.updateTitles();
+     } else {
       if (this.primeMarker) {
         this.primeMarker.closePopup();
       }
@@ -598,6 +626,9 @@ class MapPlayerPosition extends MapObject {
       if (value) {
         this.o.alt = value.z;
         this.setLatLng({ lat: value.y, lng: value.x });
+
+        // Mouse over / search titles which include the relative altitude may have changed
+        MapObject.updateTitles();
       } else {
         return;
       }


### PR DESCRIPTION
- Added capability for custom POI that could be used as altitude reference objects.
- Added example in Floor Town (Floorida?)
- Created movePlayerPosition function to be called to change altitude reference object explicitly
- Update mouse over titles and search values when the player position reference changes
- Fix problem with icon rendering placing the 'overlay' icon in the wrong place on point icons
