### PR TITLE
Add missing map data to SIU

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/public/data/custom-markers.siu.json
+++ b/public/data/custom-markers.siu.json
@@ -388,5 +388,90 @@
       "Coin620_27": 1,
       "Coin621_29": 1
     }
+  },
+  {
+    "name": "Coin695_54",
+    "area": "DLC2_Complete",
+    "delete": 0
+  },
+  {
+    "name": "Coin696",
+    "area": "DLC2_Complete",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "Coin695_54",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "Coin696",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "Coin697",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "Coin698",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "Coin699",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "Coin700",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "Coin701",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "Coin702",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "SecretFound71_2",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_PostRainbow",
+    "name": "Coin57_23",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_PostRainbow",
+    "name": "Coin61_35",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "SecretFound44_2",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Complete",
+    "name": "Coin11",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_Menu_Splash",
+    "name": "SecretFound_2",
+    "delete": 0
+  },
+  {
+    "area": "DLC2_SecretLavaArea",
+    "name": "Coin59",
+    "delete": 0
   }
 ]

--- a/public/data/custom-markers.siu.json
+++ b/public/data/custom-markers.siu.json
@@ -456,11 +456,6 @@
   },
   {
     "area": "DLC2_Complete",
-    "name": "SecretFound44_2",
-    "delete": 0
-  },
-  {
-    "area": "DLC2_Complete",
     "name": "Coin11",
     "delete": 0
   },

--- a/public/data/custom-markers.siu.json
+++ b/public/data/custom-markers.siu.json
@@ -460,11 +460,6 @@
     "delete": 0
   },
   {
-    "area": "DLC2_Menu_Splash",
-    "name": "SecretFound_2",
-    "delete": 0
-  },
-  {
     "area": "DLC2_SecretLavaArea",
     "name": "Coin59",
     "delete": 0

--- a/public/data/markers.siu.json
+++ b/public/data/markers.siu.json
@@ -16,84 +16,12 @@
     "alt": 1728.9361572265625
   },
   {
-    "name": "BallButton",
-    "type": "BallButton_C",
-    "area": "DLC2_Complete",
-    "lat": -57945.18359375,
-    "lng": 56204.41015625,
-    "alt": 4406.310546875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 57289.83984375,
-        "y": -63051.08203125,
-        "z": 4402.00537109375
-      }
-    ]
-  },
-  {
-    "name": "BallButton2",
-    "type": "BallButton_C",
-    "area": "DLC2_Complete",
-    "lat": -50491.75390625,
-    "lng": 52167.03125,
-    "alt": 464.793701171875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 51697.90625,
-        "y": -52478.375,
-        "z": 567.47412109375
-      }
-    ]
-  },
-  {
-    "name": "BallButton3_2",
-    "type": "BallButton_C",
-    "area": "DLC2_Complete",
-    "lat": -45890.19921875,
-    "lng": 44969.796875,
-    "alt": 769.1431274414062
-  },
-  {
-    "name": "BallButton4_2",
-    "type": "BallButton_C",
-    "area": "DLC2_Complete",
-    "lat": -2737.76611328125,
-    "lng": -58926.28515625,
-    "alt": 6820.4248046875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -58279.5859375,
-        "y": 366.8122863769531,
-        "z": 8097.8876953125
-      }
-    ]
-  },
-  {
-    "name": "BallButton5_2",
-    "type": "BallButton_C",
-    "area": "DLC2_Complete",
-    "lat": 6046.8515625,
-    "lng": -58583.98046875,
-    "alt": 1246.7735595703125
-  },
-  {
     "name": "BathGuyVolume_2",
     "type": "BathGuyVolume_C",
     "area": "DLC2_Complete",
     "lat": 2163.7373046875,
     "lng": 10409.3681640625,
     "alt": 2817.6240234375
-  },
-  {
-    "name": "BatteryExplosionDetector_2",
-    "type": "BatteryExplosionDetector_C",
-    "area": "DLC2_Complete",
-    "lat": -58149.9375,
-    "lng": 53001.484375,
-    "alt": 875.645751953125
   },
   {
     "name": "Bones2",
@@ -260,30 +188,6 @@
     "alt": 4165.99609375
   },
   {
-    "name": "BP_ElevatorDoor2",
-    "type": "BP_ElevatorDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -21725.19140625,
-    "lng": -73171.234375,
-    "alt": 2395.82421875
-  },
-  {
-    "name": "BP_ElevatorDoor_2",
-    "type": "BP_ElevatorDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -44174.05859375,
-    "lng": 20106.28515625,
-    "alt": 3064.625
-  },
-  {
-    "name": "BP_Fix_A4_CombatArenaDoor_2",
-    "type": "BP_Fix_A4_CombatArenaDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -39740.0,
-    "lng": 33075.0,
-    "alt": 10.0
-  },
-  {
     "name": "BP_MonsterChest2_2",
     "type": "BP_MonsterChest_C",
     "area": "DLC2_Complete",
@@ -339,15 +243,7 @@
     "lat": -27273.255859375,
     "lng": 15850.8603515625,
     "alt": -97.390380859375,
-    "cost": 30,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 16747.234375,
-        "y": -32422.802734375,
-        "z": 1445.0679931640625
-      }
-    ]
+    "cost": 30
   },
   {
     "name": "Shop_Health_5",
@@ -356,15 +252,7 @@
     "lat": -27252.009765625,
     "lng": 15985.712890625,
     "alt": -78.06648254394531,
-    "cost": 30,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 16747.234375,
-        "y": -32422.802734375,
-        "z": 1445.0679931640625
-      }
-    ]
+    "cost": 30
   },
   {
     "name": "BP_PurchaseJumpHeightPlus_2",
@@ -384,1426 +272,6 @@
     "alt": -70.26774597167969
   },
   {
-    "name": "A2_YellowBldgExitTrigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -11777.0,
-    "lng": 62571.0,
-    "alt": 3176.0
-  },
-  {
-    "name": "Area5IntroCutsceneTrigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -41980.0,
-    "lng": 21510.0,
-    "alt": 3660.0
-  },
-  {
-    "name": "BankElectricGunCheckVolume",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -46963.06640625,
-    "lng": 6013.58935546875,
-    "alt": 2281.20751953125
-  },
-  {
-    "name": "BP_A3_Rework_Locking_Fix",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -42866.53515625,
-    "lng": -250.88330078125,
-    "alt": 2383.84716796875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -899.452880859375,
-        "y": -43705.30078125,
-        "z": 2404.25
-      }
-    ]
-  },
-  {
-    "name": "BP_TownCelebrationTrigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -28666.78515625,
-    "lng": 18427.716796875,
-    "alt": 115.24168395996094
-  },
-  {
-    "name": "BP_Trigger_DisableAtmosphericFog",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 9872.8779296875,
-    "lng": 12787.8193359375,
-    "alt": 3128.0
-  },
-  {
-    "name": "BP_TriggerVolume10",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -35006.90625,
-    "lng": 20535.43359375,
-    "alt": 4028.052490234375
-  },
-  {
-    "name": "BP_TriggerVolume11",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -22247.39453125,
-    "lng": -66731.1015625,
-    "alt": 9184.779296875
-  },
-  {
-    "name": "BP_TriggerVolume12_491",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -47260.265625,
-    "lng": 46549.078125,
-    "alt": 1476.3919677734375
-  },
-  {
-    "name": "BP_TriggerVolume13_522",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 17574.3984375,
-    "lng": 22954.166015625,
-    "alt": 2677.103271484375
-  },
-  {
-    "name": "BP_TriggerVolume15",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -62533.1953125,
-    "lng": 41349.5703125,
-    "alt": 3584.96826171875
-  },
-  {
-    "name": "BP_TriggerVolume16_531",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -36331.0,
-    "lng": -1885.0,
-    "alt": 5095.0
-  },
-  {
-    "name": "BP_TriggerVolume17_221",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -27388.138671875,
-    "lng": 21058.740234375,
-    "alt": -110.2090072631836
-  },
-  {
-    "name": "BP_TriggerVolume18",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -26723.90625,
-    "lng": 21702.935546875,
-    "alt": -110.2090072631836
-  },
-  {
-    "name": "BP_TriggerVolume19_487",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -32122.197265625,
-    "lng": 15557.9609375,
-    "alt": 787.9292602539062
-  },
-  {
-    "name": "BP_TriggerVolume2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -21703.375,
-    "lng": -73625.1015625,
-    "alt": 8534.779296875
-  },
-  {
-    "name": "BP_TriggerVolume20_487",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 20144.49609375,
-    "lng": 18240.775390625,
-    "alt": 3531.0
-  },
-  {
-    "name": "BP_TriggerVolume21",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -46943.7734375,
-    "lng": 4285.0703125,
-    "alt": 1865.0
-  },
-  {
-    "name": "BP_TriggerVolume22_525",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -17267.0,
-    "lng": 45619.0,
-    "alt": 1052.0
-  },
-  {
-    "name": "BP_TriggerVolume23_494",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -44220.90234375,
-    "lng": 19651.064453125,
-    "alt": 3170.0
-  },
-  {
-    "name": "BP_TriggerVolume24",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -8646.974609375,
-    "lng": 18615.0,
-    "alt": 4992.1259765625
-  },
-  {
-    "name": "BP_TriggerVolume25_524",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 15516.2578125,
-    "lng": 21877.634765625,
-    "alt": 3133.44921875
-  },
-  {
-    "name": "BP_TriggerVolume26_487",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -44231.31640625,
-    "lng": 19626.94140625,
-    "alt": 4537.8427734375
-  },
-  {
-    "name": "BP_TriggerVolume27_490",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -32540.0,
-    "lng": 18013.767578125,
-    "alt": 3585.0
-  },
-  {
-    "name": "BP_TriggerVolume28",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -26489.375,
-    "lng": 18550.5078125,
-    "alt": -2036.3515625
-  },
-  {
-    "name": "BP_TriggerVolume29_487",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -30114.0,
-    "lng": 18492.3984375,
-    "alt": -2358.70263671875
-  },
-  {
-    "name": "BP_TriggerVolume30_522",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 17694.6953125,
-    "lng": 22962.966796875,
-    "alt": 2805.364501953125
-  },
-  {
-    "name": "BP_TriggerVolume31_525",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 15100.4248046875,
-    "lng": 23057.853515625,
-    "alt": 3100.110107421875
-  },
-  {
-    "name": "BP_TriggerVolume32",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 20438.8046875,
-    "lng": 21126.537109375,
-    "alt": 2909.784912109375
-  },
-  {
-    "name": "BP_TriggerVolume33",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 9331.1826171875,
-    "lng": 16970.17578125,
-    "alt": 3666.810791015625
-  },
-  {
-    "name": "BP_TriggerVolume34_603",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 16599.0,
-    "lng": 23023.0,
-    "alt": 3818.0
-  },
-  {
-    "name": "BP_TriggerVolume35_607",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 9619.4111328125,
-    "lng": 19750.126953125,
-    "alt": 3013.0
-  },
-  {
-    "name": "BP_TriggerVolume36_522",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -24865.111328125,
-    "lng": 20378.974609375,
-    "alt": -129.24880981445312
-  },
-  {
-    "name": "BP_TriggerVolume37_522",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -29135.0,
-    "lng": 20940.0,
-    "alt": 1460.0
-  },
-  {
-    "name": "BP_TriggerVolume38_661",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -45857.7890625,
-    "lng": 6023.6953125,
-    "alt": 2020.753173828125
-  },
-  {
-    "name": "BP_TriggerVolume39_661",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -40263.890625,
-    "lng": 33849.75,
-    "alt": 260.6277160644531
-  },
-  {
-    "name": "BP_TriggerVolume3_2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -41540.0,
-    "lng": -279.88720703125,
-    "alt": 2630.0
-  },
-  {
-    "name": "BP_TriggerVolume4",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -43506.5625,
-    "lng": -6561.5244140625,
-    "alt": 2636.175048828125
-  },
-  {
-    "name": "BP_TriggerVolume40",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 14072.4111328125,
-    "lng": 23545.46484375,
-    "alt": 3642.35498046875
-  },
-  {
-    "name": "BP_TriggerVolume41",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 13821.5390625,
-    "lng": 21734.150390625,
-    "alt": 3411.62744140625
-  },
-  {
-    "name": "BP_TriggerVolume42_524",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -21527.0,
-    "lng": 23632.0,
-    "alt": -288.0
-  },
-  {
-    "name": "BP_TriggerVolume43_522",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -36387.73828125,
-    "lng": 20685.634765625,
-    "alt": 4041.3857421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 20356.125,
-        "y": -36786.609375,
-        "z": 3622.0390625
-      }
-    ]
-  },
-  {
-    "name": "BP_TriggerVolume44",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -46722.421875,
-    "lng": 44787.4296875,
-    "alt": 839.7850341796875
-  },
-  {
-    "name": "BP_TriggerVolume45",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -45870.5234375,
-    "lng": 45550.0859375,
-    "alt": 1312.048095703125
-  },
-  {
-    "name": "BP_TriggerVolume46",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -36628.8671875,
-    "lng": 20741.451171875,
-    "alt": 4041.3857421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 21206.2890625,
-        "y": -36866.19921875,
-        "z": 3607.400390625
-      }
-    ]
-  },
-  {
-    "name": "BP_TriggerVolume47",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 15951.1923828125,
-    "lng": 18715.455078125,
-    "alt": 4039.595458984375
-  },
-  {
-    "name": "BP_TriggerVolume50_661",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -33786.0,
-    "lng": 20346.0,
-    "alt": 190.0
-  },
-  {
-    "name": "BP_TriggerVolume51_664",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 978.1974487304688,
-    "lng": 9687.26171875,
-    "alt": 3458.065673828125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 9572.201171875,
-        "y": 1355.6878662109375,
-        "z": 3200.802001953125
-      }
-    ]
-  },
-  {
-    "name": "BP_TriggerVolume52_667",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 19712.298828125,
-    "lng": 19959.208984375,
-    "alt": 3257.15283203125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 19901.6484375,
-        "y": 19485.626953125,
-        "z": 3091.51318359375
-      }
-    ]
-  },
-  {
-    "name": "BP_TriggerVolume53_661",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -16290.810546875,
-    "lng": 42493.828125,
-    "alt": 2552.579833984375
-  },
-  {
-    "name": "BP_TriggerVolume55",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -40976.546875,
-    "lng": 39483.45703125,
-    "alt": 7977.50048828125
-  },
-  {
-    "name": "BP_TriggerVolume56",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -47076.6875,
-    "lng": 4733.7314453125,
-    "alt": 1865.0
-  },
-  {
-    "name": "BP_TriggerVolume57",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -46420.43359375,
-    "lng": 4324.29443359375,
-    "alt": 1865.0
-  },
-  {
-    "name": "BP_TriggerVolume58",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -49212.0,
-    "lng": 2722.668701171875,
-    "alt": 1864.0001220703125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 5902.171875,
-        "y": -45215.02734375,
-        "z": 1859.0
-      },
-      {
-        "x": 7172.6533203125,
-        "y": -42902.0859375,
-        "z": 2191.778076171875
-      },
-      {
-        "x": 5902.171875,
-        "y": -45215.02734375,
-        "z": 1859.0
-      }
-    ]
-  },
-  {
-    "name": "BP_TriggerVolume59",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -50730.0546875,
-    "lng": 1232.4803466796875,
-    "alt": 2493.83203125
-  },
-  {
-    "name": "BP_TriggerVolume60",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -51265.4609375,
-    "lng": 4758.353515625,
-    "alt": 2182.5966796875
-  },
-  {
-    "name": "BP_TriggerVolume61",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -49253.02734375,
-    "lng": 3825.21435546875,
-    "alt": 2015.693115234375
-  },
-  {
-    "name": "BP_TriggerVolume62",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -51982.8125,
-    "lng": 3788.0791015625,
-    "alt": 2015.693115234375
-  },
-  {
-    "name": "BP_TriggerVolume63",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -47402.609375,
-    "lng": 2894.129638671875,
-    "alt": 3536.116943359375
-  },
-  {
-    "name": "BP_TriggerVolume64_661",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -27820.0,
-    "lng": 18480.0,
-    "alt": -2760.0
-  },
-  {
-    "name": "BP_TriggerVolume65_664",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -21690.572265625,
-    "lng": -73678.484375,
-    "alt": 2553.041015625
-  },
-  {
-    "name": "BP_TriggerVolume66_661",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 3834.699462890625,
-    "lng": -58458.0234375,
-    "alt": 2933.677734375
-  },
-  {
-    "name": "BP_TriggerVolume68_661",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 651.9661254882812,
-    "lng": -58314.5234375,
-    "alt": 8455.24609375
-  },
-  {
-    "name": "BP_TriggerVolume69_661",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 51.0,
-    "lng": 7502.0,
-    "alt": 196.0
-  },
-  {
-    "name": "BP_TriggerVolume6_125",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -41113.94921875,
-    "lng": 9846.1953125,
-    "alt": 2193.583984375
-  },
-  {
-    "name": "BP_TriggerVolume70_664",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 4844.2470703125,
-    "lng": 8522.01953125,
-    "alt": -7487.0
-  },
-  {
-    "name": "BP_TriggerVolume71_667",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -7242.0,
-    "lng": -1748.0,
-    "alt": 1177.0
-  },
-  {
-    "name": "BP_TriggerVolume72_661",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -26506.064453125,
-    "lng": 23648.912109375,
-    "alt": -2797.6455078125
-  },
-  {
-    "name": "BP_TriggerVolume7_484",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -38415.65625,
-    "lng": 20802.505859375,
-    "alt": 4002.105712890625
-  },
-  {
-    "name": "BP_TriggerVolume9",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -5478.40771484375,
-    "lng": 18615.0,
-    "alt": 4851.494140625
-  },
-  {
-    "name": "BP_TriggerVolume_661",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -41120.58203125,
-    "lng": 9347.6171875,
-    "alt": 2804.6494140625
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 4333.01025390625,
-    "lng": 11442.115234375,
-    "alt": 3920.155517578125
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat10",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 6307.89501953125,
-    "lng": 30305.59375,
-    "alt": 4211.63037109375
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat11",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 9405.6611328125,
-    "lng": 33300.078125,
-    "alt": 4211.626953125
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 3022.61181640625,
-    "lng": 15308.853515625,
-    "alt": 3774.389404296875
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 3747.172119140625,
-    "lng": 19186.908203125,
-    "alt": 4081.336181640625
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat4_488",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 123.41480255126953,
-    "lng": 17523.9921875,
-    "alt": 3997.513427734375
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat5",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -3436.997802734375,
-    "lng": 18064.25390625,
-    "alt": 4383.5166015625
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat6",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 6926.17724609375,
-    "lng": 32977.15234375,
-    "alt": 3909.25439453125
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat7",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 868.497802734375,
-    "lng": 38968.4140625,
-    "alt": 3201.52294921875
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat8",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 6944.41064453125,
-    "lng": 10525.33984375,
-    "alt": 3791.082763671875
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Combat9",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -2431.89208984375,
-    "lng": 17909.654296875,
-    "alt": 4445.8388671875
-  },
-  {
-    "name": "BP_TriggerVolume_A1_Fire_Prevention",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 1815.5560302734375,
-    "lng": 37550.3046875,
-    "alt": 2481.9560546875
-  },
-  {
-    "name": "BP_TriggerVolume_A1_HotBallsGuy",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 9125.3779296875,
-    "lng": 17342.79296875,
-    "alt": 3257.260009765625
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat1",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -24363.326171875,
-    "lng": 34546.57421875,
-    "alt": 1600.4052734375
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat10",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -14661.6728515625,
-    "lng": 39794.19921875,
-    "alt": 4478.326171875
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat11",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -16194.5556640625,
-    "lng": 41034.13671875,
-    "alt": 4247.55517578125
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat12",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -17218.908203125,
-    "lng": 54265.37890625,
-    "alt": 4247.56103515625
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat14",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -6467.47021484375,
-    "lng": 63576.34765625,
-    "alt": 4247.60986328125
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat15",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -14820.1162109375,
-    "lng": 62235.52734375,
-    "alt": 4247.650390625
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -20222.82421875,
-    "lng": 40796.1875,
-    "alt": 736.0849609375
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat5",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -17545.6171875,
-    "lng": 37577.4609375,
-    "alt": 4974.666015625
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat6",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -23215.90234375,
-    "lng": 36986.18359375,
-    "alt": 771.05810546875
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat8",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -17741.044921875,
-    "lng": 37537.08203125,
-    "alt": 3003.41455078125
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat_Lava",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -26092.115234375,
-    "lng": 32707.20703125,
-    "alt": 1600.41943359375
-  },
-  {
-    "name": "BP_TriggerVolume_A2_Combat_Side5",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -13019.5869140625,
-    "lng": 62828.30859375,
-    "alt": 3704.7919921875
-  },
-  {
-    "name": "BP_TriggerVolume_A3_Bank_Combat",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -46745.3828125,
-    "lng": 216.74609375,
-    "alt": 2478.0751953125
-  },
-  {
-    "name": "BP_TriggerVolume_A3_Combat",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -40037.13671875,
-    "lng": 12178.9462890625,
-    "alt": 2786.62158203125
-  },
-  {
-    "name": "BP_TriggerVolume_A3_Prevention",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -36687.62109375,
-    "lng": 14654.3125,
-    "alt": 2326.68603515625
-  },
-  {
-    "name": "BP_TriggerVolume_A3_Prevention3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -47100.72265625,
-    "lng": 1505.1573486328125,
-    "alt": 1952.238525390625
-  },
-  {
-    "name": "BP_TriggerVolume_A4_Arena_Combat1",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -55362.59375,
-    "lng": 64078.28515625,
-    "alt": 1870.38427734375
-  },
-  {
-    "name": "BP_TriggerVolume_A4_Combat",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -31655.5,
-    "lng": 28136.4453125,
-    "alt": 1600.68408203125
-  },
-  {
-    "name": "BP_TriggerVolume_A4_Combat2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -36710.3359375,
-    "lng": 32205.01171875,
-    "alt": 2786.60888671875
-  },
-  {
-    "name": "BP_TriggerVolume_A4_Combat3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -32979.20703125,
-    "lng": 26812.74609375,
-    "alt": 1600.68408203125
-  },
-  {
-    "name": "BP_TriggerVolume_A4_Prevention",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -30401.37109375,
-    "lng": 26589.5234375,
-    "alt": 2294.59521484375
-  },
-  {
-    "name": "BP_TriggerVolume_A4_Prevention2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -33994.6796875,
-    "lng": 30153.81640625,
-    "alt": 58.643157958984375
-  },
-  {
-    "name": "BP_TriggerVolume_A4_Prevention3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -56353.1875,
-    "lng": 59971.1484375,
-    "alt": 1075.0169677734375
-  },
-  {
-    "name": "BP_TriggerVolume_Area2_Entrance2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -25596.609375,
-    "lng": 29566.998046875,
-    "alt": 1252.34765625
-  },
-  {
-    "name": "BP_TriggerVolume_B2_RoofPuzzle",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -16269.734375,
-    "lng": 58426.44921875,
-    "alt": 3177.23583984375
-  },
-  {
-    "name": "BP_TriggerVolume_BoomeraxeContainer",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -11504.1474609375,
-    "lng": 40668.71875,
-    "alt": 1148.9871826171875
-  },
-  {
-    "name": "BP_TriggerVolume_Cave",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -22949.814453125,
-    "lng": 58429.578125,
-    "alt": 4231.4853515625
-  },
-  {
-    "name": "BP_TriggerVolume_CloseMagnetDoor",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -23307.216796875,
-    "lng": 32922.390625,
-    "alt": 1327.5576171875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 32687.7265625,
-        "y": -12633.00390625,
-        "z": -443.505126953125
-      }
-    ]
-  },
-  {
-    "name": "BP_TriggerVolume_CloseMagnetTutorials",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -21263.20703125,
-    "lng": 38600.41796875,
-    "alt": 1256.7132568359375
-  },
-  {
-    "name": "BP_TriggerVolume_ClosePickThrowTutorials",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -12451.0068359375,
-    "lng": 38983.86328125,
-    "alt": 4035.0498046875
-  },
-  {
-    "name": "BP_TriggerVolume_DetectKey",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -22734.7578125,
-    "lng": 58667.74609375,
-    "alt": 4231.4853515625
-  },
-  {
-    "name": "BP_TriggerVolume_ElevatorCounter",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -43869.82421875,
-    "lng": 20705.30078125,
-    "alt": 3069.484375
-  },
-  {
-    "name": "BP_TriggerVolume_Gold",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -31888.634765625,
-    "lng": 17946.984375,
-    "alt": 3961.20556640625
-  },
-  {
-    "name": "BP_TriggerVolume_HideActorsForCredits",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -21672.671875,
-    "lng": -73940.203125,
-    "alt": 8467.416015625
-  },
-  {
-    "name": "BP_TriggerVolume_InsideHospital",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 3904.214111328125,
-    "lng": 23150.865234375,
-    "alt": 3335.0
-  },
-  {
-    "name": "BP_TriggerVolume_Marius",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -15932.853515625,
-    "lng": 49995.1171875,
-    "alt": 1188.26708984375
-  },
-  {
-    "name": "BP_TriggerVolume_OpenA1Pipe",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -31805.494140625,
-    "lng": 18481.890625,
-    "alt": 171.35873413085938,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 17408.404296875,
-        "y": -32586.25390625,
-        "z": 379.67572021484375
-      },
-      {
-        "x": 20652.861328125,
-        "y": 15560.884765625,
-        "z": 3572.840087890625
-      }
-    ]
-  },
-  {
-    "name": "BP_TriggerVolume_OpenA2Pipe",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -30482.23046875,
-    "lng": 18318.46484375,
-    "alt": 171.35873413085938
-  },
-  {
-    "name": "BP_TriggerVolume_OpenMagnetDoorIfStuck",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -21968.328125,
-    "lng": 32073.8359375,
-    "alt": 607.3565673828125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 32568.529296875,
-        "y": -22761.140625,
-        "z": 795.9964599609375
-      }
-    ]
-  },
-  {
-    "name": "BP_TriggerVolume_OutsideHospital",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 4312.82421875,
-    "lng": 22759.6640625,
-    "alt": 3335.0
-  },
-  {
-    "name": "BP_TriggerVolume_PlayerLeftTown",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -24505.537109375,
-    "lng": 11806.833984375,
-    "alt": 865.27734375
-  },
-  {
-    "name": "BP_TriggerVolume_PrisonDialogue",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -41494.55078125,
-    "lng": -1261.9366455078125,
-    "alt": 1869.425537109375
-  },
-  {
-    "name": "BP_TriggerVolume_RT_Combat1",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -5353.03857421875,
-    "lng": -56478.80078125,
-    "alt": 6285.05078125
-  },
-  {
-    "name": "BP_TriggerVolume_RT_Combat2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -9095.1123046875,
-    "lng": -41927.16015625,
-    "alt": 5393.2109375
-  },
-  {
-    "name": "BP_TriggerVolume_RT_Combat3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -2817.87646484375,
-    "lng": -43934.51953125,
-    "alt": 4372.75341796875
-  },
-  {
-    "name": "BP_TriggerVolume_RT_Combat4",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -7764.53125,
-    "lng": -40312.48828125,
-    "alt": 5478.14794921875
-  },
-  {
-    "name": "BP_TriggerVolume_TeleportToElevator",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -44308.640625,
-    "lng": 19648.751953125,
-    "alt": 3236.8173828125
-  },
-  {
-    "name": "BP_TriggerVolume_Town_Combat",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -13821.5185546875,
-    "lng": 18197.669921875,
-    "alt": 1230.26611328125
-  },
-  {
-    "name": "BP_TriggerVolume_Town_Combat2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -25603.166015625,
-    "lng": 603.455810546875,
-    "alt": 2786.61962890625
-  },
-  {
-    "name": "BP_TriggerVolume_Town_Combat3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -26865.61328125,
-    "lng": 26860.3671875,
-    "alt": 1054.3580322265625
-  },
-  {
-    "name": "BP_TriggerVolume_Town_Combat4",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -24667.48046875,
-    "lng": 28703.015625,
-    "alt": 997.504638671875
-  },
-  {
-    "name": "BP_TriggerVolume_Town_Combat5",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -25174.41796875,
-    "lng": 24606.35546875,
-    "alt": 997.5035400390625
-  },
-  {
-    "name": "BP_TriggerVolume_Town_Combat6",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -9985.796875,
-    "lng": 18139.74609375,
-    "alt": 1230.265625
-  },
-  {
-    "name": "BP_TriggerVolume_Town_Combat7",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -25274.32421875,
-    "lng": 29750.671875,
-    "alt": 1230.265380859375
-  },
-  {
-    "name": "BP_TriggerVolume_Town_Combat8",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -25615.041015625,
-    "lng": 30381.73046875,
-    "alt": 1230.265380859375
-  },
-  {
-    "name": "BP_TriggerVolume_Town_Prevention",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -27736.099609375,
-    "lng": 4586.708984375,
-    "alt": 1419.333984375
-  },
-  {
-    "name": "BP_TriggerVolume_TownEntrance",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -21659.603515625,
-    "lng": 18468.701171875,
-    "alt": 20.63983154296875
-  },
-  {
-    "name": "BP_TriggerVolumePlayerLandInBossArea",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -14394.302734375,
-    "lng": 4099.4482421875,
-    "alt": 1410.7025146484375
-  },
-  {
-    "name": "BP_TriggerVolumeSetSupraSunEvening1",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -287139.75,
-    "lng": -358.74658203125,
-    "alt": 11786.0302734375
-  },
-  {
-    "name": "BP_TriggerVolumeSetSupraSunNoon",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -3761.427001953125,
-    "lng": 36836.3828125,
-    "alt": 16786.029296875
-  },
-  {
-    "name": "BP_TriggerVolumeTalkTrigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -7201.00830078125,
-    "lng": 60268.65234375,
-    "alt": 4229.1689453125
-  },
-  {
-    "name": "CheckIfPlayerIsInBank2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -49162.0,
-    "lng": 2579.0,
-    "alt": 2349.0
-  },
-  {
-    "name": "CullBlueRoyalsTrigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -41098.5546875,
-    "lng": 10001.9453125,
-    "alt": 2254.0
-  },
-  {
-    "name": "DemoOverTrigger1",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -9787.087890625,
-    "lng": 18813.2421875,
-    "alt": 4008.4873046875
-  },
-  {
-    "name": "DemoOverTrigger2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -11298.9833984375,
-    "lng": 18813.2421875,
-    "alt": 4833.37841796875
-  },
-  {
-    "name": "GetIntoFloor2Trigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -28152.0,
-    "lng": 20909.0,
-    "alt": 1817.0
-  },
-  {
-    "name": "GuardLeavePostTrigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -49107.0,
-    "lng": 4546.0,
-    "alt": 1877.0
-  },
-  {
-    "name": "NewValveDetectionVolume_GEN_VARIABLE_BP_TriggerVolume_C_CAT_485",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -14700.0634765625,
-    "lng": 62163.140625,
-    "alt": 1391.3427734375
-  },
-  {
-    "name": "NewValveDetectionVolume_GEN_VARIABLE_BP_TriggerVolume_C_CAT_490",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -9166.39453125,
-    "lng": 59665.6328125,
-    "alt": 2754.759033203125
-  },
-  {
-    "name": "NewValveDetectionVolume_GEN_VARIABLE_BP_TriggerVolume_C_CAT_619",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -14664.3154296875,
-    "lng": 62213.16796875,
-    "alt": 1391.5087890625
-  },
-  {
-    "name": "NewValveDetectionVolume_GEN_VARIABLE_BP_TriggerVolume_C_CAT_621",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -9118.740234375,
-    "lng": 59732.34375,
-    "alt": 2754.978515625
-  },
-  {
-    "name": "NOSTUARTBADSTUARTDONTSKIPTHISSTUARTTRIGGER",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -24277.0,
-    "lng": 18529.0,
-    "alt": 493.89013671875
-  },
-  {
-    "name": "PostStealGoldTrigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -30540.0,
-    "lng": 18505.0,
-    "alt": 3140.0
-  },
-  {
-    "name": "PostStealGoldTrigger2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -32668.0,
-    "lng": 20936.0,
-    "alt": 3427.0
-  },
-  {
-    "name": "PreStealGoldTrigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -30565.0,
-    "lng": 18505.0,
-    "alt": 3140.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 17354.271484375,
-        "y": -25500.7734375,
-        "z": -148.09979248046875
-      }
-    ]
-  },
-  {
-    "name": "Trigger_Area3_InspectorRun2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -42902.0859375,
-    "lng": 7172.6533203125,
-    "alt": 2191.778076171875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 5902.171875,
-        "y": -45215.02734375,
-        "z": 1859.0
-      }
-    ]
-  },
-  {
-    "name": "Trigger_Area3_Intro2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -45215.02734375,
-    "lng": 5902.171875,
-    "alt": 1859.0
-  },
-  {
-    "name": "trigger_beach_hint",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -35859.46484375,
-    "lng": 14790.7529296875,
-    "alt": 3884.454345703125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 8937.830078125,
-        "y": -43396.73046875,
-        "z": 2463.414306640625
-      },
-      {
-        "x": 18539.6328125,
-        "y": -32586.25390625,
-        "z": 381.9172668457031
-      }
-    ]
-  },
-  {
-    "name": "Trigger_ElevatorRising_RainbowTown",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -21632.609375,
-    "lng": -73690.7734375,
-    "alt": 4162.0
-  },
-  {
     "name": "BP_TrophyDetector_2",
     "type": "BP_TrophyDetector_C",
     "area": "DLC2_Complete",
@@ -1818,521 +286,7 @@
     "lat": -27308.482421875,
     "lng": 15581.537109375,
     "alt": -92.87537384033203,
-    "cost": 60,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 16747.234375,
-        "y": -32422.802734375,
-        "z": 1445.0679931640625
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor-FatNPC2",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -47705.51953125,
-    "lng": -6.793715953826904,
-    "alt": 3265.543701171875,
-    "variant": "orange"
-  },
-  {
-    "name": "ButtonFloor11_7",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -13531.57421875,
-    "lng": 55461.53515625,
-    "alt": 456.56219482421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 55657.515625,
-        "y": -12407.3828125,
-        "z": 1076.7496337890625
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor12",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -54853.6328125,
-    "lng": 56879.890625,
-    "alt": 457.311279296875,
-    "variant": "yellow"
-  },
-  {
-    "name": "ButtonFloor13",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -54246.45703125,
-    "lng": 56912.84765625,
-    "alt": 4339.16064453125,
-    "variant": "yellow",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 55670.5859375,
-        "y": -55967.0703125,
-        "z": 5635.62548828125
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor14",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -44801.83984375,
-    "lng": 51324.2890625,
-    "alt": 1903.3919677734375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 52389.79296875,
-        "y": -44942.26171875,
-        "z": 1933.3919677734375
-      },
-      {
-        "x": 52390.6484375,
-        "y": -44252.85546875,
-        "z": 1933.3919677734375
-      },
-      {
-        "x": 51439.4921875,
-        "y": -43441.68359375,
-        "z": 1933.3919677734375
-      },
-      {
-        "x": 51119.0859375,
-        "y": -43185.8671875,
-        "z": 1922.3084716796875
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor15",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -48448.203125,
-    "lng": 52027.265625,
-    "alt": 3185.39208984375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 51458.890625,
-        "y": -47589.53125,
-        "z": 1908.3919677734375
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor16",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -45938.80859375,
-    "lng": 39874.14453125,
-    "alt": 871.0582275390625
-  },
-  {
-    "name": "ButtonFloor17_8797",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -46958.078125,
-    "lng": 44538.59375,
-    "alt": 752.3919677734375,
-    "variant": "yellow",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 45890.671875,
-        "y": -45936.65625,
-        "z": 884.2994995117188
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor18",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -61027.3515625,
-    "lng": 48627.52734375,
-    "alt": 252.6885986328125
-  },
-  {
-    "name": "ButtonFloor19",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -47705.5234375,
-    "lng": -783.9344482421875,
-    "alt": 3264.465576171875,
-    "variant": "orange"
-  },
-  {
-    "name": "ButtonFloor20",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -48915.171875,
-    "lng": 54269.49609375,
-    "alt": 1899.688232421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 53783.0078125,
-        "y": -48447.2890625,
-        "z": 1882.085693359375
-      },
-      {
-        "x": 54587.3671875,
-        "y": -48442.0234375,
-        "z": 1898.003173828125
-      },
-      {
-        "x": 54824.19921875,
-        "y": -48838.23828125,
-        "z": 1883.357421875
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor21",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -14936.9189453125,
-    "lng": -57327.4609375,
-    "alt": 10673.400390625,
-    "variant": "orange"
-  },
-  {
-    "name": "ButtonFloor22",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -9821.26953125,
-    "lng": -58246.1640625,
-    "alt": 8252.22265625,
-    "variant": "yellow"
-  },
-  {
-    "name": "ButtonFloor23",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -5429.21142578125,
-    "lng": -46161.9453125,
-    "alt": 8258.677734375,
-    "variant": "orange"
-  },
-  {
-    "name": "ButtonFloor24_6100",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -10382.8505859375,
-    "lng": 55441.80859375,
-    "alt": 457.0
-  },
-  {
-    "name": "ButtonFloor25",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -22553.19140625,
-    "lng": 20208.427734375,
-    "alt": 1867.7869873046875,
-    "variant": "yellow",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 21204.779296875,
-        "y": -23399.736328125,
-        "z": 1358.5970458984375
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor26_6103",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -8312.263671875,
-    "lng": 62087.359375,
-    "alt": 414.0
-  },
-  {
-    "name": "ButtonFloor27_8796",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": 5436.916015625,
-    "lng": -56796.73828125,
-    "alt": 1852.55322265625,
-    "variant": "yellow"
-  },
-  {
-    "name": "ButtonFloor2_5",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -15678.0498046875,
-    "lng": 57937.83203125,
-    "alt": 429.43939208984375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 58759.33984375,
-        "y": -14990.53515625,
-        "z": 790.1314086914062
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor3_1",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -15136.0673828125,
-    "lng": 61236.5546875,
-    "alt": 1247.4632568359375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 61141.05859375,
-        "y": -14539.9306640625,
-        "z": 2017.8280029296875
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor4_2",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -8443.95703125,
-    "lng": 60879.45703125,
-    "alt": 416.1670227050781,
-    "variant": "yellow",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 61646.1796875,
-        "y": -8696.66796875,
-        "z": 430.0
-      },
-      {
-        "x": 61175.1796875,
-        "y": -9174.66796875,
-        "z": 430.0
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor5",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -10139.3388671875,
-    "lng": 62757.96875,
-    "alt": 413.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 62126.890625,
-        "y": -10445.6357421875,
-        "z": 426.6930847167969
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor6",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -14866.97265625,
-    "lng": 60902.03515625,
-    "alt": 429.43939208984375
-  },
-  {
-    "name": "ButtonFloor7",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -39299.9296875,
-    "lng": -4829.150390625,
-    "alt": 1804.862060546875
-  },
-  {
-    "name": "ButtonFloor8_2",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -46267.83203125,
-    "lng": 44519.6484375,
-    "alt": 113.3919677734375,
-    "variant": "yellow",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 45712.9921875,
-        "y": -47041.1015625,
-        "z": 119.3919677734375
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor9",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -42713.89453125,
-    "lng": -6100.939453125,
-    "alt": 2499.52734375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -5817.6357421875,
-        "y": -43431.0,
-        "z": 2516.0
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor_2",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": 19706.345703125,
-    "lng": 20397.435546875,
-    "alt": 3077.958740234375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 19901.6484375,
-        "y": 19485.626953125,
-        "z": 3091.51318359375
-      }
-    ]
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_1147",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -36486.97265625,
-    "lng": 15846.412109375,
-    "alt": 2212.987548828125
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_1560",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -42663.59375,
-    "lng": 8899.5283203125,
-    "alt": 1881.3597412109375
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_2107",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -21426.66015625,
-    "lng": 32141.333984375,
-    "alt": -571.8511962890625
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_2707",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -9247.4814453125,
-    "lng": 60509.9375,
-    "alt": 4185.54248046875
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_3508",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -48634.15234375,
-    "lng": 37124.09765625,
-    "alt": -528.1012573242188
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_3737",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -59063.32421875,
-    "lng": 57628.36328125,
-    "alt": 876.9898071289062
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_378",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -15904.810546875,
-    "lng": 21700.32421875,
-    "alt": 512.699951171875
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_4617",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -30248.953125,
-    "lng": 22006.912109375,
-    "alt": 3107.3056640625
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_5215",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": 4524.21240234375,
-    "lng": 31310.2109375,
-    "alt": 4131.1064453125
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_5622",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -31574.693359375,
-    "lng": 16975.8359375,
-    "alt": -63.4862060546875
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_6029",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -14149.3154296875,
-    "lng": 39948.52734375,
-    "alt": 4089.94580078125
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_6705",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": 2509.00439453125,
-    "lng": 22889.623046875,
-    "alt": 3280.296142578125
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_7814",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -22946.064453125,
-    "lng": 22226.9296875,
-    "alt": 1486.14990234375
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_8142",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -14054.6884765625,
-    "lng": 52124.515625,
-    "alt": 578.587890625
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_8619",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -33786.87109375,
-    "lng": 29124.43359375,
-    "alt": -60.01104736328125
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_8704",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": -48147.10546875,
-    "lng": 1621.6630859375,
-    "alt": 1899.662109375
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_8868",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_Complete",
-    "lat": 1536.3089599609375,
-    "lng": -57961.47265625,
-    "alt": 8361.7314453125
+    "cost": 60
   },
   {
     "name": "BuyBrokenPipeDetector_2",
@@ -2386,15 +340,7 @@
     "lat": -27285.935546875,
     "lng": 15713.7216796875,
     "alt": -79.1365966796875,
-    "cost": 30,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 16747.234375,
-        "y": -32422.802734375,
-        "z": 1445.0679931640625
-      }
-    ]
+    "cost": 30
   },
   {
     "name": "BuyStats_2",
@@ -7696,1014 +5642,6 @@
     "alt": 3176.125244140625
   },
   {
-    "name": "Door23",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -41999.98828125,
-    "lng": 3266.08056640625,
-    "alt": 1785.0
-  },
-  {
-    "name": "Door24",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -44340.2109375,
-    "lng": -888.1235961914062,
-    "alt": 1788.560302734375
-  },
-  {
-    "name": "Door29_2",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -41840.41015625,
-    "lng": 34549.02734375,
-    "alt": -148.0
-  },
-  {
-    "name": "Door42",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -29731.703125,
-    "lng": 20746.556640625,
-    "alt": -189.96975708007812
-  },
-  {
-    "name": "Door43",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -24419.78515625,
-    "lng": 20002.458984375,
-    "alt": -189.99989318847656
-  },
-  {
-    "name": "Door45",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -23582.98828125,
-    "lng": 16224.8232421875,
-    "alt": -190.00552368164062
-  },
-  {
-    "name": "Door59",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -24134.328125,
-    "lng": 17359.08984375,
-    "alt": 369.46392822265625
-  },
-  {
-    "name": "Door60",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -29439.150390625,
-    "lng": 16837.97265625,
-    "alt": -174.81690979003906
-  },
-  {
-    "name": "Door63_1",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -23399.736328125,
-    "lng": 21204.779296875,
-    "alt": 1358.5970458984375
-  },
-  {
-    "name": "Door64",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -31075.884765625,
-    "lng": 21355.55078125,
-    "alt": 1368.5726318359375
-  },
-  {
-    "name": "Door66",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -40614.36328125,
-    "lng": 8707.5263671875,
-    "alt": 1751.0
-  },
-  {
-    "name": "Door81",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -45959.70703125,
-    "lng": 2621.1474609375,
-    "alt": 1754.9993896484375
-  },
-  {
-    "name": "Door82",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -45959.70703125,
-    "lng": 3145.056640625,
-    "alt": 1754.9993896484375
-  },
-  {
-    "name": "PrintingPressDoor",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -39360.01171875,
-    "lng": 4273.95166015625,
-    "alt": 1776.392578125
-  },
-  {
-    "name": "PrintingPressDoor6",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -48393.7109375,
-    "lng": 2497.65478515625,
-    "alt": 1776.392578125
-  },
-  {
-    "name": "PrintingPressDoor7",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -49109.65625,
-    "lng": 3972.358642578125,
-    "alt": 1777.80322265625
-  },
-  {
-    "name": "PrintingPressDoor8",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -51105.08203125,
-    "lng": 749.010498046875,
-    "alt": 1804.52099609375
-  },
-  {
-    "name": "PrintingPressDoor9",
-    "type": "Door3_C",
-    "area": "DLC2_Complete",
-    "lat": -50048.4140625,
-    "lng": 4122.708984375,
-    "alt": 2716.578369140625
-  },
-  {
-    "name": "A4_PreventReturnDoor",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -39977.16796875,
-    "lng": 33289.6328125,
-    "alt": -162.39273071289062
-  },
-  {
-    "name": "Door10",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": 4078.95654296875,
-    "lng": 22976.232421875,
-    "alt": 3175.9169921875
-  },
-  {
-    "name": "Door11",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -8696.66796875,
-    "lng": 61646.1796875,
-    "alt": 430.0
-  },
-  {
-    "name": "Door12",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -15195.318359375,
-    "lng": 62473.234375,
-    "alt": 1260.0
-  },
-  {
-    "name": "Door13",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -10053.7783203125,
-    "lng": 57627.94140625,
-    "alt": 429.999755859375
-  },
-  {
-    "name": "Door14",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -10445.6357421875,
-    "lng": 62126.890625,
-    "alt": 426.6930847167969
-  },
-  {
-    "name": "Door17",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -51979.1953125,
-    "lng": 3947.465576171875,
-    "alt": 1765.0
-  },
-  {
-    "name": "Door21",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -42670.0078125,
-    "lng": 3976.028076171875,
-    "alt": 1775.0
-  },
-  {
-    "name": "Door27_2",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -56288.2265625,
-    "lng": 59469.1796875,
-    "alt": 827.57275390625
-  },
-  {
-    "name": "Door28",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": 1919.9566650390625,
-    "lng": 37507.84375,
-    "alt": 2334.32861328125
-  },
-  {
-    "name": "Door2_2",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -43431.0,
-    "lng": -5817.6357421875,
-    "alt": 2516.0
-  },
-  {
-    "name": "Door30",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -47263.6171875,
-    "lng": 1499.7320556640625,
-    "alt": 1765.000244140625
-  },
-  {
-    "name": "Door31_2",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -13252.0302734375,
-    "lng": 58770.12890625,
-    "alt": 454.06219482421875
-  },
-  {
-    "name": "Door32",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": 3845.076171875,
-    "lng": 35948.39453125,
-    "alt": 3082.530029296875
-  },
-  {
-    "name": "Door33",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -34042.734375,
-    "lng": 30271.216796875,
-    "alt": -235.56643676757812
-  },
-  {
-    "name": "Door34",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -47589.53125,
-    "lng": 51458.890625,
-    "alt": 1908.3919677734375
-  },
-  {
-    "name": "Door36",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -47245.203125,
-    "lng": 46620.1015625,
-    "alt": 1296.3939208984375
-  },
-  {
-    "name": "Door37",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -47870.03125,
-    "lng": 52179.0546875,
-    "alt": 1887.3919677734375
-  },
-  {
-    "name": "Door38",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -50746.16796875,
-    "lng": 41626.99609375,
-    "alt": 236.39208984375
-  },
-  {
-    "name": "Door3_2",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -49432.828125,
-    "lng": 41587.6484375,
-    "alt": 236.3919677734375
-  },
-  {
-    "name": "Door4",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": 2994.3984375,
-    "lng": 11299.919921875,
-    "alt": 3079.77734375
-  },
-  {
-    "name": "Door40",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -48442.0234375,
-    "lng": 54587.3671875,
-    "alt": 1898.003173828125
-  },
-  {
-    "name": "Door41",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -48788.54296875,
-    "lng": 54812.765625,
-    "alt": 2425.09228515625
-  },
-  {
-    "name": "Door44_5",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -16304.748046875,
-    "lng": 45204.16015625,
-    "alt": 491.5870361328125
-  },
-  {
-    "name": "Door46",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -30989.529296875,
-    "lng": 18486.2578125,
-    "alt": -225.7982177734375
-  },
-  {
-    "name": "Door47",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -12407.3828125,
-    "lng": 55657.515625,
-    "alt": 1076.7496337890625
-  },
-  {
-    "name": "Door48_2",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -30080.2265625,
-    "lng": 24766.119140625,
-    "alt": 1959.0
-  },
-  {
-    "name": "Door49_2",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -36530.859375,
-    "lng": 14696.103515625,
-    "alt": 2095.99462890625
-  },
-  {
-    "name": "Door5",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": 2524.99462890625,
-    "lng": 20303.86328125,
-    "alt": 2989.917236328125
-  },
-  {
-    "name": "Door50",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": 4766.80908203125,
-    "lng": 18889.99609375,
-    "alt": 3108.076904296875
-  },
-  {
-    "name": "Door51_2",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -26980.380859375,
-    "lng": 21470.119140625,
-    "alt": -158.72586059570312
-  },
-  {
-    "name": "Door52_2",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -30324.0,
-    "lng": 26477.0,
-    "alt": 2052.0
-  },
-  {
-    "name": "Door53",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -30374.443359375,
-    "lng": 26537.11328125,
-    "alt": 2052.0
-  },
-  {
-    "name": "Door54",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -41041.4609375,
-    "lng": 10140.9189453125,
-    "alt": 2055.63232421875
-  },
-  {
-    "name": "Door55",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -48209.30859375,
-    "lng": 54142.4296875,
-    "alt": 1898.003173828125
-  },
-  {
-    "name": "Door56",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -31997.25,
-    "lng": 28373.76953125,
-    "alt": -222.37901306152344
-  },
-  {
-    "name": "Door57",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": 19485.626953125,
-    "lng": 19901.6484375,
-    "alt": 3091.51318359375
-  },
-  {
-    "name": "Door6",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -14539.9306640625,
-    "lng": 61141.05859375,
-    "alt": 2017.8280029296875
-  },
-  {
-    "name": "Door61_3",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -28071.19921875,
-    "lng": 25914.9296875,
-    "alt": -56.081024169921875
-  },
-  {
-    "name": "Door62",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": 1355.6878662109375,
-    "lng": 9572.201171875,
-    "alt": 3200.802001953125
-  },
-  {
-    "name": "Door65",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -4491.70458984375,
-    "lng": 18393.283203125,
-    "alt": 4119.03857421875
-  },
-  {
-    "name": "Door67",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -27722.6796875,
-    "lng": 4626.26611328125,
-    "alt": 1129.2943115234375
-  },
-  {
-    "name": "Door68",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -26816.68359375,
-    "lng": -348.32745361328125,
-    "alt": 1065.91015625
-  },
-  {
-    "name": "Door69",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -39897.9609375,
-    "lng": 33208.35546875,
-    "alt": -162.39260864257812
-  },
-  {
-    "name": "Door7",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -12044.0234375,
-    "lng": 58271.4140625,
-    "alt": 1251.61572265625
-  },
-  {
-    "name": "Door70",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -55872.6171875,
-    "lng": 64871.6796875,
-    "alt": 621.9130249023438
-  },
-  {
-    "name": "Door71",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -52368.6484375,
-    "lng": 47171.2734375,
-    "alt": 424.59423828125
-  },
-  {
-    "name": "Door72",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -19875.9296875,
-    "lng": 36699.18359375,
-    "alt": 3833.993408203125
-  },
-  {
-    "name": "Door73",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -14816.46484375,
-    "lng": 39844.19921875,
-    "alt": 3941.48681640625
-  },
-  {
-    "name": "Door75",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -9174.66796875,
-    "lng": 61175.1796875,
-    "alt": 430.0
-  },
-  {
-    "name": "Door76",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -47234.86328125,
-    "lng": -911.4496459960938,
-    "alt": 1762.9151611328125
-  },
-  {
-    "name": "Door77",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -50422.62109375,
-    "lng": 760.13916015625,
-    "alt": 1765.0
-  },
-  {
-    "name": "Door78",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -47332.39453125,
-    "lng": -379.5649108886719,
-    "alt": 3243.9931640625
-  },
-  {
-    "name": "Door79",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -47210.11328125,
-    "lng": 1499.731201171875,
-    "alt": 1765.000244140625
-  },
-  {
-    "name": "Door8",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -9111.01953125,
-    "lng": 59957.9609375,
-    "alt": 3407.328369140625
-  },
-  {
-    "name": "Door9_2",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -8842.76953125,
-    "lng": 59689.88671875,
-    "alt": 430.0
-  },
-  {
-    "name": "Door_2",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": 11956.4375,
-    "lng": 27661.9765625,
-    "alt": 3932.0
-  },
-  {
-    "name": "Door_Race",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -25032.84375,
-    "lng": 50100.109375,
-    "alt": 2928.615478515625
-  },
-  {
-    "name": "DoorInverted9_5",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -36334.7109375,
-    "lng": 6480.240234375,
-    "alt": 1758.5294189453125
-  },
-  {
-    "name": "DoorStone7",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -56441.5,
-    "lng": 54356.2109375,
-    "alt": 2644.8037109375
-  },
-  {
-    "name": "DoorSus",
-    "type": "Door_C",
-    "area": "DLC2_Complete",
-    "lat": -32892.859375,
-    "lng": 29192.556640625,
-    "alt": -235.56643676757812
-  },
-  {
-    "name": "DoorAnna10",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -46374.90234375,
-    "lng": 50212.9453125,
-    "alt": 1881.3919677734375
-  },
-  {
-    "name": "DoorAnna11_2",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -43552.4453125,
-    "lng": 34985.94140625,
-    "alt": 442.3324279785156
-  },
-  {
-    "name": "DoorAnna12",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -26589.140625,
-    "lng": 20094.6015625,
-    "alt": -2484.142822265625
-  },
-  {
-    "name": "DoorAnna13_2",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -20188.08984375,
-    "lng": 21801.501953125,
-    "alt": -121.0
-  },
-  {
-    "name": "DoorAnna14_2",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -31751.57421875,
-    "lng": 18288.947265625,
-    "alt": 1359.071533203125
-  },
-  {
-    "name": "DoorAnna15",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -26597.53515625,
-    "lng": 21146.65234375,
-    "alt": 1350.6864013671875
-  },
-  {
-    "name": "DoorAnna17",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -30909.466796875,
-    "lng": 18438.189453125,
-    "alt": 2947.2294921875
-  },
-  {
-    "name": "DoorAnna18_2",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -43417.90234375,
-    "lng": 50530.4921875,
-    "alt": 1953.3919677734375
-  },
-  {
-    "name": "DoorAnna19",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -56201.96484375,
-    "lng": 53142.203125,
-    "alt": 493.94805908203125
-  },
-  {
-    "name": "DoorAnna2",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -40886.30078125,
-    "lng": 397.1480712890625,
-    "alt": 1777.0
-  },
-  {
-    "name": "DoorAnna20",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -20418.41015625,
-    "lng": 13485.70703125,
-    "alt": -169.4905242919922
-  },
-  {
-    "name": "DoorAnna21",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -46521.86328125,
-    "lng": -1593.3048095703125,
-    "alt": 3261.53955078125
-  },
-  {
-    "name": "DoorAnna4_2",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -28168.91796875,
-    "lng": 16032.69140625,
-    "alt": -211.0
-  },
-  {
-    "name": "DoorAnna6_2",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -48475.5703125,
-    "lng": 45208.0546875,
-    "alt": 372.0
-  },
-  {
-    "name": "DoorAnna7",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -54877.6484375,
-    "lng": 52633.96875,
-    "alt": 1001.9237060546875
-  },
-  {
-    "name": "DoorAnna8_2",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -20228.533203125,
-    "lng": 13520.916015625,
-    "alt": -169.4905242919922
-  },
-  {
-    "name": "DoorAnna9",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -54614.171875,
-    "lng": 52861.0,
-    "alt": 1001.9237060546875
-  },
-  {
-    "name": "DoorAnna_2",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Complete",
-    "lat": -40844.0,
-    "lng": -1839.81689453125,
-    "alt": 1777.0
-  },
-  {
-    "name": "Door80",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -51505.046875,
-    "lng": -1082.681640625,
-    "alt": 1765.0
-  },
-  {
-    "name": "Door_MagnetBeltPath",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -22761.140625,
-    "lng": 32568.529296875,
-    "alt": 795.9964599609375
-  },
-  {
-    "name": "DoorInverted10_2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -43185.8671875,
-    "lng": 51119.0859375,
-    "alt": 1922.3084716796875
-  },
-  {
-    "name": "DoorInverted11",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -47113.23828125,
-    "lng": 5457.78955078125,
-    "alt": 1765.5106201171875
-  },
-  {
-    "name": "DoorInverted12",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -47264.7109375,
-    "lng": 2887.645751953125,
-    "alt": 3264.0
-  },
-  {
-    "name": "DoorInverted13",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -47113.23828125,
-    "lng": 5455.947265625,
-    "alt": 1764.0281982421875
-  },
-  {
-    "name": "DoorInverted14_2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -47041.1015625,
-    "lng": 45712.9921875,
-    "alt": 119.3919677734375
-  },
-  {
-    "name": "DoorInverted15_2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": 366.8122863769531,
-    "lng": -58279.5859375,
-    "alt": 8097.8876953125
-  },
-  {
-    "name": "DoorInverted16",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": 1382.2998046875,
-    "lng": -58735.390625,
-    "alt": 1206.8673095703125
-  },
-  {
-    "name": "DoorInverted2_2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -43705.30078125,
-    "lng": -899.452880859375,
-    "alt": 2404.25
-  },
-  {
-    "name": "DoorInverted3_3",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -44942.26171875,
-    "lng": 52389.79296875,
-    "alt": 1933.3919677734375
-  },
-  {
-    "name": "DoorInverted4",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -44252.85546875,
-    "lng": 52390.6484375,
-    "alt": 1933.3919677734375
-  },
-  {
-    "name": "DoorInverted5",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -43441.68359375,
-    "lng": 51439.4921875,
-    "alt": 1933.3919677734375
-  },
-  {
-    "name": "DoorInverted6",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -48447.2890625,
-    "lng": 53783.0078125,
-    "alt": 1882.085693359375
-  },
-  {
-    "name": "DoorInverted7",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -48838.23828125,
-    "lng": 54824.19921875,
-    "alt": 1883.357421875
-  },
-  {
-    "name": "DoorInverted8_2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_Complete",
-    "lat": -6978.3095703125,
-    "lng": -49191.65625,
-    "alt": 7995.59326171875
-  },
-  {
-    "name": "DoorLego2",
-    "type": "DoorLego_C",
-    "area": "DLC2_Complete",
-    "lat": -5344.49169921875,
-    "lng": -43100.5,
-    "alt": 9070.7861328125
-  },
-  {
-    "name": "DoorLego3_2",
-    "type": "DoorLego_C",
-    "area": "DLC2_Complete",
-    "lat": -11900.578125,
-    "lng": 39876.3984375,
-    "alt": 839.3283081054688
-  },
-  {
-    "name": "DoorLego4_2",
-    "type": "DoorLego_C",
-    "area": "DLC2_Complete",
-    "lat": -24670.9140625,
-    "lng": 22273.421875,
-    "alt": 1299.7144775390625
-  },
-  {
-    "name": "DoorLego_2",
-    "type": "DoorLego_C",
-    "area": "DLC2_Complete",
-    "lat": -55967.0703125,
-    "lng": 55670.5859375,
-    "alt": 5635.62548828125
-  },
-  {
-    "name": "DoorStone10_2",
-    "type": "DoorStone_C",
-    "area": "DLC2_Complete",
-    "lat": -63051.08203125,
-    "lng": 57289.83984375,
-    "alt": 4402.00537109375
-  },
-  {
-    "name": "DoorStone2",
-    "type": "DoorStone_C",
-    "area": "DLC2_Complete",
-    "lat": -38128.97265625,
-    "lng": 436.35888671875,
-    "alt": 1774.5968017578125
-  },
-  {
-    "name": "DoorStone3",
-    "type": "DoorStone_C",
-    "area": "DLC2_Complete",
-    "lat": -34023.04296875,
-    "lng": 20756.978515625,
-    "alt": 3813.618896484375
-  },
-  {
-    "name": "DoorStone4_2",
-    "type": "DoorStone_C",
-    "area": "DLC2_Complete",
-    "lat": -36866.19921875,
-    "lng": 21206.2890625,
-    "alt": 3607.400390625
-  },
-  {
-    "name": "DoorStone5",
-    "type": "DoorStone_C",
-    "area": "DLC2_Complete",
-    "lat": -37456.97265625,
-    "lng": 3065.35888671875,
-    "alt": 3244.0
-  },
-  {
-    "name": "DoorStone6",
-    "type": "DoorStone_C",
-    "area": "DLC2_Complete",
-    "lat": -50592.78125,
-    "lng": 56277.73046875,
-    "alt": 474.403076171875
-  },
-  {
-    "name": "DoorStone8",
-    "type": "DoorStone_C",
-    "area": "DLC2_Complete",
-    "lat": -36786.609375,
-    "lng": 20356.125,
-    "alt": 3622.0390625
-  },
-  {
-    "name": "DoorStone9_2",
-    "type": "DoorStone_C",
-    "area": "DLC2_Complete",
-    "lat": -23307.369140625,
-    "lng": 37498.77734375,
-    "alt": 5149.1767578125
-  },
-  {
-    "name": "DoorStone_2",
-    "type": "DoorStone_C",
-    "area": "DLC2_Complete",
-    "lat": -15431.25,
-    "lng": 47748.89453125,
-    "alt": 409.68878173828125
-  },
-  {
     "name": "BankElectricityPuzzle_1_ExplodingBattery",
     "type": "ExplodingBattery_C",
     "area": "DLC2_Complete",
@@ -8774,30 +5712,6 @@
     "lat": -21431.76953125,
     "lng": 40774.94921875,
     "alt": 7124.7890625
-  },
-  {
-    "name": "GoldNugget15_2",
-    "type": "GoldNugget_C",
-    "area": "DLC2_Complete",
-    "lat": -32024.107421875,
-    "lng": 17790.611328125,
-    "alt": 3858.435791015625
-  },
-  {
-    "name": "GoldNugget4",
-    "type": "GoldNugget_C",
-    "area": "DLC2_Complete",
-    "lat": -39465.33203125,
-    "lng": -849.189453125,
-    "alt": 1791.4608154296875
-  },
-  {
-    "name": "GoldNugget6",
-    "type": "GoldNugget_C",
-    "area": "DLC2_Complete",
-    "lat": -39485.16015625,
-    "lng": -1013.5029296875,
-    "alt": 1794.5843505859375
   },
   {
     "name": "HealingStation10_35",
@@ -8936,78 +5850,6 @@
     "alt": 512.699951171875
   },
   {
-    "name": "JailDoor10_2",
-    "type": "JailDoor_C",
-    "area": "DLC2_Complete",
-    "lat": 8144.7060546875,
-    "lng": 28349.39453125,
-    "alt": 3706.699462890625
-  },
-  {
-    "name": "JailDoor2",
-    "type": "JailDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -41772.29296875,
-    "lng": -730.89794921875,
-    "alt": 1775.544677734375
-  },
-  {
-    "name": "JailDoor3",
-    "type": "JailDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -41231.28515625,
-    "lng": -1329.853515625,
-    "alt": 1777.0
-  },
-  {
-    "name": "JailDoor5",
-    "type": "JailDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -43979.921875,
-    "lng": -1192.9296875,
-    "alt": 2404.0
-  },
-  {
-    "name": "JailDoor6",
-    "type": "JailDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -43427.921875,
-    "lng": -1181.8074951171875,
-    "alt": 2401.0439453125
-  },
-  {
-    "name": "JailDoor7",
-    "type": "JailDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -40297.29296875,
-    "lng": -732.8974609375,
-    "alt": 1778.0
-  },
-  {
-    "name": "JailDoor8",
-    "type": "JailDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -40634.29296875,
-    "lng": -192.94287109375,
-    "alt": 1777.0
-  },
-  {
-    "name": "JailDoor9",
-    "type": "JailDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -40422.29296875,
-    "lng": 354.1031799316406,
-    "alt": 1778.0
-  },
-  {
-    "name": "JailDoor_2",
-    "type": "JailDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -41231.29296875,
-    "lng": -192.90625,
-    "alt": 1777.0
-  },
-  {
     "name": "Jumppad10_2",
     "type": "Jumppad_C",
     "area": "DLC2_Complete",
@@ -9015,9 +5857,9 @@
     "lng": 17775.4453125,
     "alt": 3131.557861328125,
     "target": {
-      "x": 19589.315145223984,
-      "y": 9674.555170192809,
-      "z": 3012.703165088927
+      "x": 19589.31510335647,
+      "y": 9674.555087079598,
+      "z": 3012.7030752772553
     },
     "linetype": "jumppad",
     "variant": "red"
@@ -9076,9 +5918,9 @@
     "lng": 53700.4453125,
     "alt": 3575.69775390625,
     "target": {
-      "x": 54059.11207359494,
-      "y": -57326.26488622767,
-      "z": 3632.829624840237
+      "x": 54059.11202904477,
+      "y": -57326.264885076205,
+      "z": 3632.8295541345874
     },
     "linetype": "jumppad",
     "variant": "red",
@@ -9092,9 +5934,9 @@
     "lng": 53013.69921875,
     "alt": 550.591552734375,
     "target": {
-      "x": 54309.17696666396,
-      "y": -57137.92060564255,
-      "z": 3573.88979567955
+      "x": 54309.176823923095,
+      "y": -57137.92075399514,
+      "z": 3573.889596488306
     },
     "linetype": "jumppad",
     "variant": "red"
@@ -9123,9 +5965,9 @@
     "lng": 53063.578125,
     "alt": 537.6765747070312,
     "target": {
-      "x": 52989.14055351655,
-      "y": -56859.41256072497,
-      "z": 3153.5752863777757
+      "x": 52989.14055556976,
+      "y": -56859.41261204877,
+      "z": 3153.5749616259063
     },
     "linetype": "jumppad",
     "variant": "red"
@@ -9155,7 +5997,7 @@
     "target": {
       "x": -48241.37109375,
       "y": -29318.4765625,
-      "z": 17278.455754882933
+      "z": 17278.45549550012
     },
     "linetype": "jumppad",
     "variant": "blue"
@@ -9168,9 +6010,9 @@
     "lng": 41889.8515625,
     "alt": -579.4031982421875,
     "target": {
-      "x": 39729.258698249876,
-      "y": -46452.84948822511,
-      "z": 1805.9066604676038
+      "x": 39729.25873988992,
+      "y": -46452.84975119983,
+      "z": 1805.9065257577304
     },
     "linetype": "jumppad",
     "variant": "red"
@@ -9199,7 +6041,7 @@
     "alt": 3263.00634765625,
     "target": {
       "x": 41658.67184346914,
-      "y": -62158.04871118069,
+      "y": -62158.048501968384,
       "z": 3278.348175628725
     },
     "linetype": "jumppad",
@@ -9215,8 +6057,8 @@
     "alt": -2519.508544921875,
     "target": {
       "x": 31702.646484375,
-      "y": -20878.332082956473,
-      "z": -574.5178262213146
+      "y": -20878.332183208786,
+      "z": -574.5178202255062
     },
     "linetype": "jumppad",
     "variant": "red"
@@ -9230,7 +6072,7 @@
     "alt": -151.15478515625,
     "target": {
       "x": 28651.87970869243,
-      "y": -38550.50218800455,
+      "y": -38550.502278491855,
       "z": -164.34830671718294
     },
     "linetype": "jumppad",
@@ -9245,9 +6087,9 @@
     "lng": 35262.24609375,
     "alt": 1002.8065185546875,
     "target": {
-      "x": 34238.38836014271,
+      "x": 34238.38847279549,
       "y": -36836.34429755062,
-      "z": 918.2304520387684
+      "z": 918.230564691547
     },
     "linetype": "jumppad",
     "variant": "blue",
@@ -9310,8 +6152,8 @@
     "alt": 8213.736328125,
     "target": {
       "x": -58051.77316753232,
-      "y": -7749.5596142578115,
-      "z": 8209.546333671393
+      "y": -7749.559609968749,
+      "z": 8209.54633367139
     },
     "linetype": "jumppad",
     "variant": "red",
@@ -9325,9 +6167,9 @@
     "lng": 17354.271484375,
     "alt": -148.09979248046875,
     "target": {
-      "x": 18589.249495074415,
-      "y": -30377.316010693583,
-      "z": 2999.3162481952327
+      "x": 18589.250700651515,
+      "y": -30377.31585106624,
+      "z": 2999.315778570993
     },
     "linetype": "jumppad",
     "variant": "red"
@@ -9401,9 +6243,9 @@
     "lng": 30354.216796875,
     "alt": 3574.655029296875,
     "target": {
-      "x": 32195.752611726522,
-      "y": 6695.263719551265,
-      "z": 3900.5711987370587
+      "x": 32195.752387315035,
+      "y": 6695.263691499829,
+      "z": 3900.5714231485463
     },
     "linetype": "jumppad",
     "variant": "red"
@@ -9446,8 +6288,8 @@
     "lng": 50827.7734375,
     "alt": 510.0,
     "target": {
-      "x": 52902.15809249878,
-      "y": -14722.990203857422,
+      "x": 52902.15779495239,
+      "y": -14722.990798950195,
       "z": 515.5642811279581
     },
     "linetype": "jumppad",
@@ -9485,285 +6327,13 @@
     "variant": "red"
   },
   {
-    "name": "Jumppillow_2",
-    "type": "Jumppillow_C",
-    "area": "DLC2_Complete",
-    "lat": -55726.3984375,
-    "lng": 46973.15625,
-    "alt": 585.8670654296875
-  },
-  {
-    "name": "Key3",
-    "type": "Key_C",
-    "area": "DLC2_Complete",
-    "lat": -52228.203125,
-    "lng": 47199.1640625,
-    "alt": -533.878173828125
-  },
-  {
-    "name": "KeycardColor2",
-    "type": "KeycardColor_C",
-    "area": "DLC2_Complete",
-    "lat": -40253.625,
-    "lng": -1734.120849609375,
-    "alt": 1877.6624755859375,
-    "variant": "green"
-  },
-  {
-    "name": "KeycardColor3_2",
-    "type": "KeycardColor_C",
-    "area": "DLC2_Complete",
-    "lat": -47974.51171875,
-    "lng": 4578.21533203125,
-    "alt": 1819.7711181640625
-  },
-  {
-    "name": "KeycardColor4",
-    "type": "KeycardColor_C",
-    "area": "DLC2_Complete",
-    "lat": -47973.56640625,
-    "lng": 4568.236328125,
-    "alt": 1896.2939453125,
-    "variant": "red"
-  },
-  {
-    "name": "KeycardColor5",
-    "type": "KeycardColor_C",
-    "area": "DLC2_Complete",
-    "lat": -47907.53125,
-    "lng": 4566.7060546875,
-    "alt": 1773.879638671875,
-    "variant": "red"
-  },
-  {
-    "name": "KeycardColor6",
-    "type": "KeycardColor_C",
-    "area": "DLC2_Complete",
-    "lat": -47972.62890625,
-    "lng": 4510.29833984375,
-    "alt": 1819.7716064453125
-  },
-  {
-    "name": "KeycardColor7_2",
-    "type": "KeycardColor_C",
-    "area": "DLC2_Complete",
-    "lat": -26261.052734375,
-    "lng": 21480.673828125,
-    "alt": 1447.3681640625,
-    "variant": "purple"
-  },
-  {
-    "name": "KeycardColor_2",
-    "type": "KeycardColor_C",
-    "area": "DLC2_Complete",
-    "lat": -40335.6171875,
-    "lng": -1734.129150390625,
-    "alt": 1877.6624755859375,
-    "variant": "green"
-  },
-  {
-    "name": "KeycardReader2_2",
-    "type": "KeycardReader_C",
-    "area": "DLC2_Complete",
-    "lat": -25352.3671875,
-    "lng": 22298.849609375,
-    "alt": 1502.5069580078125,
-    "variant": "purple",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 22273.421875,
-        "y": -24670.9140625,
-        "z": 1299.7144775390625
-      }
-    ]
-  },
-  {
-    "name": "KeycardReader3",
-    "type": "KeycardReader_C",
-    "area": "DLC2_Complete",
-    "lat": -40684.125,
-    "lng": -622.4583740234375,
-    "alt": 1940.0,
-    "variant": "orange",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -192.94287109375,
-        "y": -40634.29296875,
-        "z": 1777.0
-      }
-    ]
-  },
-  {
-    "name": "KeycardReader4_2",
-    "type": "KeycardReader_C",
-    "area": "DLC2_Complete",
-    "lat": -41404.10546875,
-    "lng": 10096.009765625,
-    "alt": 2191.429443359375,
-    "variant": "green",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 10140.9189453125,
-        "y": -41041.4609375,
-        "z": 2055.63232421875
-      }
-    ]
-  },
-  {
-    "name": "KeycardReader5_2",
-    "type": "KeycardReader_C",
-    "area": "DLC2_Complete",
-    "lat": -47326.62890625,
-    "lng": 5409.0322265625,
-    "alt": 1900.51416015625,
-    "variant": "red",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 5455.947265625,
-        "y": -47113.23828125,
-        "z": 1764.0281982421875
-      }
-    ]
-  },
-  {
-    "name": "KeycardReader6_8",
-    "type": "KeycardReader_C",
-    "area": "DLC2_Complete",
-    "lat": -46460.3203125,
-    "lng": 4002.134765625,
-    "alt": 3114.1103515625,
-    "variant": "yellow"
-  },
-  {
-    "name": "KeycardReader7",
-    "type": "KeycardReader_C",
-    "area": "DLC2_Complete",
-    "lat": -42925.65234375,
-    "lng": 3937.3720703125,
-    "alt": 1902.881103515625,
-    "variant": "blue",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 3976.028076171875,
-        "y": -42670.0078125,
-        "z": 1775.0
-      }
-    ]
-  },
-  {
-    "name": "KeyLock8_2",
-    "type": "KeyLock_C",
-    "area": "DLC2_Complete",
-    "lat": -52353.9921875,
-    "lng": 47191.03125,
-    "alt": 529.594482421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 47171.2734375,
-        "y": -52368.6484375,
-        "z": 424.59423828125
-      }
-    ]
-  },
-  {
-    "name": "KeyLockPlastic10_5",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_Complete",
-    "lat": 5973.7802734375,
-    "lng": 17726.09765625,
-    "alt": 3107.09423828125
-  },
-  {
-    "name": "KeyLockPlastic2_2",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_Complete",
-    "lat": -10039.5458984375,
-    "lng": 57658.76953125,
-    "alt": 554.7304077148438
-  },
-  {
-    "name": "KeyLockPlastic3_2",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_Complete",
-    "lat": -32185.9296875,
-    "lng": 17983.173828125,
-    "alt": 3990.0546875,
-    "variant": "purple"
-  },
-  {
-    "name": "KeyLockPlastic4_5",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_Complete",
-    "lat": -39393.85546875,
-    "lng": 4129.68505859375,
-    "alt": 1898.389892578125,
-    "variant": "red"
-  },
-  {
-    "name": "KeyLockPlastic5_8",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_Complete",
-    "lat": -26518.765625,
-    "lng": 20057.3671875,
-    "alt": -2364.673583984375,
-    "variant": "green"
-  },
-  {
-    "name": "KeyLockPlastic6_11",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_Complete",
-    "lat": -47207.578125,
-    "lng": 46650.703125,
-    "alt": 1404.035888671875,
-    "variant": "orange"
-  },
-  {
-    "name": "KeyLockPlastic7_2",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_Complete",
-    "lat": 1432.8079833984375,
-    "lng": -58722.6484375,
-    "alt": 1330.340576171875
-  },
-  {
-    "name": "KeyLockPlastic8_5",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_Complete",
-    "lat": 2965.51220703125,
-    "lng": 11270.697265625,
-    "alt": 3191.43212890625,
-    "variant": "blue"
-  },
-  {
-    "name": "KeyLockPlastic9_2",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_Complete",
-    "lat": -23502.841796875,
-    "lng": 16220.7568359375,
-    "alt": -113.6812744140625
-  },
-  {
-    "name": "KeyLockPlastic_2",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_Complete",
-    "lat": -12031.7919921875,
-    "lng": 39926.7734375,
-    "alt": 986.3282470703125
-  },
-  {
     "name": "KeyPlastic2_2",
     "type": "KeyPlastic_C",
     "area": "DLC2_Complete",
     "lat": -32139.642578125,
     "lng": 17539.626953125,
     "alt": 3548.81298828125,
-    "variant": "purple"
+    "variant": "yellow"
   },
   {
     "name": "KeyPlastic3_7",
@@ -9772,7 +6342,7 @@
     "lat": -42815.91015625,
     "lng": 5081.8369140625,
     "alt": 1914.4849853515625,
-    "variant": "red"
+    "variant": "white"
   },
   {
     "name": "KeyPlastic4_10",
@@ -9790,7 +6360,7 @@
     "lat": -42661.6015625,
     "lng": 50433.77734375,
     "alt": 2026.05419921875,
-    "variant": "orange"
+    "variant": "blue"
   },
   {
     "name": "KeyPlastic7_2",
@@ -9799,7 +6369,7 @@
     "lat": 1036.0755615234375,
     "lng": 9822.853515625,
     "alt": 3264.112548828125,
-    "variant": "blue"
+    "variant": "orange"
   },
   {
     "name": "KeyPlastic8_2",
@@ -9807,7 +6377,8 @@
     "area": "DLC2_Complete",
     "lat": 4865.1513671875,
     "lng": 23861.056640625,
-    "alt": 3746.44140625
+    "alt": 3746.44140625,
+    "variant": "cyan"
   },
   {
     "name": "KeyPlastic9_2",
@@ -9815,7 +6386,8 @@
     "area": "DLC2_Complete",
     "lat": -23551.095703125,
     "lng": 14341.8359375,
-    "alt": 1122.739990234375
+    "alt": 1122.739990234375,
+    "variant": "grey"
   },
   {
     "name": "KeyPlastic_4",
@@ -9824,253 +6396,6 @@
     "lat": -11516.7880859375,
     "lng": 40117.25,
     "alt": 1468.337646484375
-  },
-  {
-    "name": "Lever10_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -20820.953125,
-    "lng": 21885.814453125,
-    "alt": -110.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 21801.501953125,
-        "y": -20188.08984375,
-        "z": -121.0
-      }
-    ]
-  },
-  {
-    "name": "Lever11_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -30245.7734375,
-    "lng": 24642.03125,
-    "alt": 2023.79150390625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 26477.0,
-        "y": -30324.0,
-        "z": 2052.0
-      }
-    ]
-  },
-  {
-    "name": "Lever12_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -54846.67578125,
-    "lng": 52939.76171875,
-    "alt": 19.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 52861.0,
-        "y": -54614.171875,
-        "z": 1001.9237060546875
-      },
-      {
-        "x": 52633.96875,
-        "y": -54877.6484375,
-        "z": 1001.9237060546875
-      }
-    ]
-  },
-  {
-    "name": "Lever13_5",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -24545.6171875,
-    "lng": 14738.234375,
-    "alt": 1431.0
-  },
-  {
-    "name": "Lever14_4",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -17705.02734375,
-    "lng": 45718.265625,
-    "alt": 1503.8736572265625
-  },
-  {
-    "name": "Lever15_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": 12212.10546875,
-    "lng": 22151.060546875,
-    "alt": 3546.497314453125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 22501.416015625,
-        "y": 13195.0986328125,
-        "z": 3545.837890625
-      },
-      {
-        "x": 20962.060546875,
-        "y": 12369.5380859375,
-        "z": 3910.046875
-      }
-    ]
-  },
-  {
-    "name": "Lever16_5",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -26721.009765625,
-    "lng": 25888.611328125,
-    "alt": 935.6543579101562,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 25914.9296875,
-        "y": -28071.19921875,
-        "z": -56.081024169921875
-      }
-    ]
-  },
-  {
-    "name": "Lever18_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -12049.1865234375,
-    "lng": 41341.203125,
-    "alt": 2864.204345703125
-  },
-  {
-    "name": "Lever2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -47761.7734375,
-    "lng": 52597.5625,
-    "alt": 1954.3919677734375
-  },
-  {
-    "name": "Lever3_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -13367.5986328125,
-    "lng": 59401.58203125,
-    "alt": 482.4542236328125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 58770.12890625,
-        "y": -13252.0302734375,
-        "z": 454.06219482421875
-      },
-      {
-        "x": 50827.7734375,
-        "y": -21646.8125,
-        "z": 510.0
-      }
-    ]
-  },
-  {
-    "name": "Lever4_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -12030.666015625,
-    "lng": 56362.8828125,
-    "alt": 500.0
-  },
-  {
-    "name": "Lever5_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -54541.671875,
-    "lng": 43405.0078125,
-    "alt": 1261.9051513671875
-  },
-  {
-    "name": "Lever6_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -31891.646484375,
-    "lng": 18115.40234375,
-    "alt": 3880.006591796875
-  },
-  {
-    "name": "Lever7_4",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -14685.8837890625,
-    "lng": 59016.1328125,
-    "alt": 603.8480224609375
-  },
-  {
-    "name": "Lever8_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -16951.251953125,
-    "lng": 44808.20703125,
-    "alt": 550.175048828125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 45204.16015625,
-        "y": -16304.748046875,
-        "z": 491.5870361328125
-      }
-    ]
-  },
-  {
-    "name": "Lever9_5",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -28175.091796875,
-    "lng": 19982.1640625,
-    "alt": 1171.785400390625
-  },
-  {
-    "name": "Lever_2",
-    "type": "Lever_C",
-    "area": "DLC2_Complete",
-    "lat": 17323.8984375,
-    "lng": 22270.150390625,
-    "alt": 3853.4931640625
-  },
-  {
-    "name": "Lift1_2",
-    "type": "Lift1_C",
-    "area": "DLC2_Complete",
-    "lat": -28958.625,
-    "lng": 17963.0625,
-    "alt": -2434.26953125
-  },
-  {
-    "name": "Lift2",
-    "type": "Lift1_C",
-    "area": "DLC2_Complete",
-    "lat": -48438.828125,
-    "lng": 52036.6484375,
-    "alt": 1984.3919677734375
-  },
-  {
-    "name": "Match_Lever2",
-    "type": "Match_Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -37370.0,
-    "lng": 4126.0361328125,
-    "alt": 1880.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 3801.644287109375,
-        "y": -36690.25390625,
-        "z": 2049.9375
-      }
-    ]
-  },
-  {
-    "name": "Match_Lever_2",
-    "type": "Match_Lever_C",
-    "area": "DLC2_Complete",
-    "lat": -15625.55078125,
-    "lng": 46879.984375,
-    "alt": -45.4281005859375
   },
   {
     "name": "MatchBox10",
@@ -11305,15 +7630,7 @@
     "lat": -28565.4453125,
     "lng": 16424.0859375,
     "alt": -70.25227355957031,
-    "variant": "diamond",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 16464.306640625,
-        "y": -28558.439453125,
-        "z": -72.95669555664062
-      }
-    ]
+    "variant": "diamond"
   },
   {
     "name": "MinecraftBrick222",
@@ -11322,15 +7639,7 @@
     "lat": -28355.296875,
     "lng": 16407.796875,
     "alt": -70.25227355957031,
-    "variant": "metal",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 16443.494140625,
-        "y": -28352.66015625,
-        "z": -57.282127380371094
-      }
-    ]
+    "variant": "metal"
   },
   {
     "name": "MinecraftBrick223",
@@ -13182,15 +9491,7 @@
     "lat": -28173.287109375,
     "lng": 16389.86328125,
     "alt": -70.25227355957031,
-    "variant": "stone",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 16432.439453125,
-        "y": -28170.8125,
-        "z": -77.56555938720703
-      }
-    ]
+    "variant": "stone"
   },
   {
     "name": "MinecraftBrick436_2",
@@ -13199,15 +9500,7 @@
     "lat": -42432.33984375,
     "lng": 34473.66796875,
     "alt": 1180.6717529296875,
-    "variant": "stone",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 34985.94140625,
-        "y": -43552.4453125,
-        "z": 442.3324279785156
-      }
-    ]
+    "variant": "stone"
   },
   {
     "name": "MinecraftBrick437_11",
@@ -13951,20 +10244,7 @@
     "area": "DLC2_Complete",
     "lat": -27230.173828125,
     "lng": 15973.8408203125,
-    "alt": -42.494197845458984,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 15985.712890625,
-        "y": -27252.009765625,
-        "z": -78.06648254394531
-      },
-      {
-        "x": 16747.234375,
-        "y": -32422.802734375,
-        "z": 1445.0679931640625
-      }
-    ]
+    "alt": -42.494197845458984
   },
   {
     "name": "MinecraftBrickRespawnable22",
@@ -13972,20 +10252,7 @@
     "area": "DLC2_Complete",
     "lat": -27268.337890625,
     "lng": 15708.0263671875,
-    "alt": -42.49417495727539,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 15713.7216796875,
-        "y": -27285.935546875,
-        "z": -79.1365966796875
-      },
-      {
-        "x": 16747.234375,
-        "y": -32422.802734375,
-        "z": 1445.0679931640625
-      }
-    ]
+    "alt": -42.49417495727539
   },
   {
     "name": "MinecraftBrickRespawnable23",
@@ -13993,20 +10260,7 @@
     "area": "DLC2_Complete",
     "lat": -27248.427734375,
     "lng": 15846.7158203125,
-    "alt": -42.49419403076172,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 15850.8603515625,
-        "y": -27273.255859375,
-        "z": -97.390380859375
-      },
-      {
-        "x": 16747.234375,
-        "y": -32422.802734375,
-        "z": 1445.0679931640625
-      }
-    ]
+    "alt": -42.49419403076172
   },
   {
     "name": "MinecraftBrickRespawnable3_2",
@@ -14022,1619 +10276,7 @@
     "area": "DLC2_Complete",
     "lat": -27285.353515625,
     "lng": 15589.5166015625,
-    "alt": -42.49445343017578,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 15581.537109375,
-        "y": -27308.482421875,
-        "z": -92.87537384033203
-      },
-      {
-        "x": 16747.234375,
-        "y": -32422.802734375,
-        "z": 1445.0679931640625
-      }
-    ]
-  },
-  {
-    "name": "BankElectricityPuzzle_1_PedestalButton_ResetBattery",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -51360.97265625,
-    "lng": 3371.258056640625,
-    "alt": 3230.788818359375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 3331.307373046875,
-        "y": -51228.29296875,
-        "z": 3106.970703125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton10",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -20519.833984375,
-    "lng": 60106.67578125,
-    "alt": 3963.5419921875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 62331.7109375,
-        "y": -17893.37890625,
-        "z": 510.00341796875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton100_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 17262.2578125,
-    "lng": 19722.01171875,
-    "alt": 3699.432861328125
-  },
-  {
-    "name": "PedestalButton101_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -52297.2578125,
-    "lng": 47255.4609375,
-    "alt": -57.17307662963867,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 47199.1640625,
-        "y": -52228.203125,
-        "z": -533.878173828125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton102_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -49395.0,
-    "lng": 53095.0,
-    "alt": 1905.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 53220.69921875,
-        "y": -49544.36328125,
-        "z": 1975.7183837890625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton102_NewAndImproved",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -31550.009765625,
-    "lng": 27655.666015625,
-    "alt": -239.3452606201172
-  },
-  {
-    "name": "PedestalButton103",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -288940.65625,
-    "lng": 321.0,
-    "alt": 10292.11328125
-  },
-  {
-    "name": "PedestalButton104",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -47285.0625,
-    "lng": 6349.39306640625,
-    "alt": 2948.888671875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 6315.63623046875,
-        "y": -47331.4765625,
-        "z": 2949.21484375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton105",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -50154.640625,
-    "lng": 4072.542724609375,
-    "alt": 2663.843505859375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 4122.708984375,
-        "y": -50048.4140625,
-        "z": 2716.578369140625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton106_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -42613.6640625,
-    "lng": 148.39683532714844,
-    "alt": 1810.873779296875
-  },
-  {
-    "name": "PedestalButton107_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 501.7955322265625,
-    "lng": -58674.19140625,
-    "alt": 8093.3203125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -58279.5859375,
-        "y": 366.8122863769531,
-        "z": 8097.8876953125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton11",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -11077.685546875,
-    "lng": 63672.58984375,
-    "alt": 4026.762451171875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 55923.72265625,
-        "y": -15603.8349609375,
-        "z": 510.0
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton12",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -10631.54296875,
-    "lng": 62433.5234375,
-    "alt": 439.53228759765625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 62274.234375,
-        "y": -10631.638671875,
-        "z": 443.014404296875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton13_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -47933.08984375,
-    "lng": 4474.078125,
-    "alt": 1720.2431640625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 4568.236328125,
-        "y": -47973.56640625,
-        "z": 1896.2939453125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton14_5",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -40436.796875,
-    "lng": -1736.479248046875,
-    "alt": 1776.9998779296875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -1734.129150390625,
-        "y": -40335.6171875,
-        "z": 1877.6624755859375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton16_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -47782.80078125,
-    "lng": 51607.19140625,
-    "alt": 1886.420654296875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 51458.890625,
-        "y": -47589.53125,
-        "z": 1908.3919677734375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton17",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -40599.35546875,
-    "lng": -1151.2259521484375,
-    "alt": 1758.004150390625
-  },
-  {
-    "name": "PedestalButton18_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -26400.51953125,
-    "lng": 21285.0859375,
-    "alt": 1360.39306640625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 21480.673828125,
-        "y": -26261.052734375,
-        "z": 1447.3681640625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton19_5",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -33499.23046875,
-    "lng": 20738.306640625,
-    "alt": 2876.884521484375
-  },
-  {
-    "name": "PedestalButton20_8",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -31868.146484375,
-    "lng": 18712.177734375,
-    "alt": 1359.071533203125
-  },
-  {
-    "name": "PedestalButton21",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -51991.75,
-    "lng": -933.1396484375,
-    "alt": 1746.620361328125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 3947.465576171875,
-        "y": -51979.1953125,
-        "z": 1765.0
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton23",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -37081.19921875,
-    "lng": 3710.468994140625,
-    "alt": 2947.52880859375
-  },
-  {
-    "name": "PedestalButton24",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -38514.75,
-    "lng": -850.6549072265625,
-    "alt": 1754.999267578125
-  },
-  {
-    "name": "PedestalButton25_11",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -26123.55859375,
-    "lng": 22450.455078125,
-    "alt": 1910.8546142578125
-  },
-  {
-    "name": "PedestalButton26_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -63200.0546875,
-    "lng": 57178.109375,
-    "alt": 4371.37353515625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 57289.83984375,
-        "y": -63051.08203125,
-        "z": 4402.00537109375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton27",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -48552.3203125,
-    "lng": 1536.70849609375,
-    "alt": 1760.2174072265625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 1499.7320556640625,
-        "y": -47263.6171875,
-        "z": 1765.000244140625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton28",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -46712.8046875,
-    "lng": 39213.84375,
-    "alt": 2559.67138671875
-  },
-  {
-    "name": "PedestalButton29_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -45925.48828125,
-    "lng": 6119.56689453125,
-    "alt": 3271.079833984375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 5635.47119140625,
-        "y": -43150.7421875,
-        "z": 1833.4017333984375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton2_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -31350.150390625,
-    "lng": 17752.04296875,
-    "alt": 568.8074951171875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 18486.2578125,
-        "y": -30989.529296875,
-        "z": -225.7982177734375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton3",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 2238.164306640625,
-    "lng": 11787.7744140625,
-    "alt": 3120.9814453125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 11668.91796875,
-        "y": 2340.185302734375,
-        "z": 3202.112548828125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton30_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -23454.140625,
-    "lng": 20993.587890625,
-    "alt": 1490.30517578125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 21204.779296875,
-        "y": -23399.736328125,
-        "z": 1358.5970458984375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton31_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -23543.037109375,
-    "lng": 15735.98828125,
-    "alt": 906.9166259765625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 14341.8359375,
-        "y": -23551.095703125,
-        "z": 1122.739990234375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton32_7",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -47125.19921875,
-    "lng": 34780.47265625,
-    "alt": 1538.6019287109375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 34785.2734375,
-        "y": -47033.66015625,
-        "z": 1620.1282958984375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton34",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -46676.828125,
-    "lng": 38564.29296875,
-    "alt": 748.3919677734375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 38863.0,
-        "y": -46690.0,
-        "z": 726.2919311523438
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton35_8",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -50755.01171875,
-    "lng": 40355.71875,
-    "alt": -262.2195129394531,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 41587.6484375,
-        "y": -49432.828125,
-        "z": 236.3919677734375
-      },
-      {
-        "x": 39259.44921875,
-        "y": -50166.0234375,
-        "z": -433.5423583984375
-      },
-      {
-        "x": 39375.75390625,
-        "y": -50126.78125,
-        "z": -412.04638671875
-      },
-      {
-        "x": 39428.28515625,
-        "y": -50058.7265625,
-        "z": -412.04638671875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton36",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -46648.78125,
-    "lng": 40228.38671875,
-    "alt": 1659.7330322265625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 41889.8515625,
-        "y": -46658.4140625,
-        "z": -579.4031982421875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton37_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 6514.99853515625,
-    "lng": 31686.875,
-    "alt": 3900.78515625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 30354.216796875,
-        "y": 6396.71826171875,
-        "z": 3574.655029296875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton38",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -46492.1171875,
-    "lng": 50260.6796875,
-    "alt": 1923.3919677734375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 50212.9453125,
-        "y": -46374.90234375,
-        "z": 1881.3919677734375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton39",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -57134.6328125,
-    "lng": 52774.51171875,
-    "alt": 3524.626953125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 53063.578125,
-        "y": -58719.88671875,
-        "z": 537.6765747070312
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton40",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -57901.921875,
-    "lng": 53752.71484375,
-    "alt": 4403.298828125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 53013.69921875,
-        "y": -58911.76171875,
-        "z": 550.591552734375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton41",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -42501.84765625,
-    "lng": 50550.7265625,
-    "alt": 1930.3919677734375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 50433.77734375,
-        "y": -42661.6015625,
-        "z": 2026.05419921875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton42",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -53872.5625,
-    "lng": 50512.5,
-    "alt": 233.34976196289062,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 49958.46875,
-        "y": -55478.33203125,
-        "z": 1244.8753662109375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton43",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -56137.56640625,
-    "lng": 49206.9296875,
-    "alt": 338.4817810058594
-  },
-  {
-    "name": "PedestalButton44",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -56091.96484375,
-    "lng": 55728.26953125,
-    "alt": 951.6207275390625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 55474.0078125,
-        "y": -56075.640625,
-        "z": 1026.4268798828125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton45",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -50221.76171875,
-    "lng": 55931.7109375,
-    "alt": 462.8076171875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 56277.73046875,
-        "y": -50592.78125,
-        "z": 474.403076171875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton46_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -43224.0,
-    "lng": -6824.0,
-    "alt": 2519.0
-  },
-  {
-    "name": "PedestalButton47_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -12633.00390625,
-    "lng": 32687.7265625,
-    "alt": -443.505126953125
-  },
-  {
-    "name": "PedestalButton48",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -46491.578125,
-    "lng": 39283.71484375,
-    "alt": 2342.53466796875
-  },
-  {
-    "name": "PedestalButton49",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -46442.703125,
-    "lng": 39117.95703125,
-    "alt": 2331.8974609375
-  },
-  {
-    "name": "PedestalButton4_1",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 856.9375610351562,
-    "lng": 9741.4794921875,
-    "alt": 3193.521484375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 9822.853515625,
-        "y": 1036.0755615234375,
-        "z": 3264.112548828125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton5",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 4769.29052734375,
-    "lng": 23721.73828125,
-    "alt": 3674.6845703125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 23861.056640625,
-        "y": 4865.1513671875,
-        "z": 3746.44140625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton50",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -45608.19140625,
-    "lng": 40131.26953125,
-    "alt": 2324.37548828125
-  },
-  {
-    "name": "PedestalButton51",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -53732.0234375,
-    "lng": 54416.234375,
-    "alt": 485.3956298828125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 54356.2109375,
-        "y": -56441.5,
-        "z": 2644.8037109375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton52",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -15200.978515625,
-    "lng": -54812.14453125,
-    "alt": 9249.78515625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -54653.3046875,
-        "y": -15208.3837890625,
-        "z": 9263.556640625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton53",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -10966.5283203125,
-    "lng": -58720.4921875,
-    "alt": 8320.8046875
-  },
-  {
-    "name": "PedestalButton54",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -15216.404296875,
-    "lng": -54812.72265625,
-    "alt": 9371.203125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -54654.4609375,
-        "y": -15208.4267578125,
-        "z": 9390.333984375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton55_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -44310.0,
-    "lng": -6290.0,
-    "alt": 2519.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -6050.39794921875,
-        "y": -44217.09375,
-        "z": 2653.6767578125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton56",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -7638.07763671875,
-    "lng": -43045.140625,
-    "alt": 9058.224609375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -42687.1171875,
-        "y": -7543.880859375,
-        "z": 9225.650390625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton58",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -24427.1484375,
-    "lng": 20155.40625,
-    "alt": -216.69960021972656,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 20002.458984375,
-        "y": -24419.78515625,
-        "z": -189.99989318847656
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton59",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -29802.404296875,
-    "lng": 20894.083984375,
-    "alt": -219.60972595214844,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 20746.556640625,
-        "y": -29731.703125,
-        "z": -189.96975708007812
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton6",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 1824.73681640625,
-    "lng": 15803.8134765625,
-    "alt": 3492.711669921875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 16209.8173828125,
-        "y": 2970.6826171875,
-        "z": 3217.068603515625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton60",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -12545.38671875,
-    "lng": 16661.662109375,
-    "alt": 6258.5732421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 19814.46484375,
-        "y": -12873.2890625,
-        "z": 2194.414306640625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton61",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -32165.154296875,
-    "lng": 17673.95703125,
-    "alt": 3492.26416015625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 17539.626953125,
-        "y": -32139.642578125,
-        "z": 3548.81298828125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton62_5",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 15460.0546875,
-    "lng": 21978.380859375,
-    "alt": 3107.375732421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 21873.923828125,
-        "y": 15505.8818359375,
-        "z": 3155.722900390625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton63_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -39222.02734375,
-    "lng": -973.9864501953125,
-    "alt": 4376.37255859375
-  },
-  {
-    "name": "PedestalButton64_5",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -38871.4375,
-    "lng": 2253.625244140625,
-    "alt": 4102.640625
-  },
-  {
-    "name": "PedestalButton65_8",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -36332.578125,
-    "lng": 4713.1845703125,
-    "alt": 2943.02587890625
-  },
-  {
-    "name": "PedestalButton66",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -5452.09521484375,
-    "lng": -43767.2421875,
-    "alt": 7149.09326171875
-  },
-  {
-    "name": "PedestalButton67",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -5326.49951171875,
-    "lng": -43060.5,
-    "alt": 9790.787109375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -43100.5,
-        "y": -5344.49169921875,
-        "z": 9070.7861328125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton68",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -9826.4697265625,
-    "lng": -43520.5,
-    "alt": 9020.7900390625
-  },
-  {
-    "name": "PedestalButton69_5",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 13016.533203125,
-    "lng": 28355.419921875,
-    "alt": 3036.4091796875
-  },
-  {
-    "name": "PedestalButton70_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -43028.0,
-    "lng": 4961.0,
-    "alt": 1768.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 5081.8369140625,
-        "y": -42815.91015625,
-        "z": 1914.4849853515625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton71_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -41687.47265625,
-    "lng": 34284.5625,
-    "alt": -32.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 34549.02734375,
-        "y": -41840.41015625,
-        "z": -148.0
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton72_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 18009.36328125,
-    "lng": 21930.6484375,
-    "alt": 3142.144775390625
-  },
-  {
-    "name": "PedestalButton73_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -21228.85546875,
-    "lng": 40640.82421875,
-    "alt": 7023.31591796875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 40774.94921875,
-        "y": -21431.76953125,
-        "z": 7124.7890625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton74",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -10599.1611328125,
-    "lng": 62003.40234375,
-    "alt": 393.5957946777344,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 62126.890625,
-        "y": -10445.6357421875,
-        "z": 426.6930847167969
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton75_8",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 13599.5068359375,
-    "lng": 27299.15625,
-    "alt": 3046.0380859375
-  },
-  {
-    "name": "PedestalButton76_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -29831.0,
-    "lng": 24415.0,
-    "alt": 1717.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 24391.212890625,
-        "y": -29656.037109375,
-        "z": 1728.9361572265625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton77_4",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 8913.294921875,
-    "lng": 20120.314453125,
-    "alt": 3407.689697265625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 18889.99609375,
-        "y": 4766.80908203125,
-        "z": 3108.076904296875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton78",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 4581.80908203125,
-    "lng": 18901.751953125,
-    "alt": 3115.194091796875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 18889.99609375,
-        "y": 4766.80908203125,
-        "z": 3108.076904296875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton79_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -16979.73828125,
-    "lng": 60514.28515625,
-    "alt": 1213.5826416015625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 60380.48828125,
-        "y": -16967.123046875,
-        "z": 1215.1781005859375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton7_6",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -15489.6767578125,
-    "lng": 61765.83203125,
-    "alt": 431.5621643066406,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 61870.984375,
-        "y": -15603.2978515625,
-        "z": 430.830322265625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton80_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 8677.064453125,
-    "lng": 17071.748046875,
-    "alt": 3122.757568359375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 16841.919921875,
-        "y": 8612.2197265625,
-        "z": 3324.004150390625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton81_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 10219.9775390625,
-    "lng": 29195.650390625,
-    "alt": 3305.344482421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 29205.951171875,
-        "y": 10129.42578125,
-        "z": 3352.87646484375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton82_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -48676.0,
-    "lng": 45491.0,
-    "alt": 371.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 45208.0546875,
-        "y": -48475.5703125,
-        "z": 372.0
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton83_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -6400.4443359375,
-    "lng": -49152.64453125,
-    "alt": 8265.4765625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -49191.65625,
-        "y": -6978.3095703125,
-        "z": 7995.59326171875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton84",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -46624.86328125,
-    "lng": -1259.8466796875,
-    "alt": 1765.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 760.13916015625,
-        "y": -50422.62109375,
-        "z": 1765.0
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton85",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -51451.34375,
-    "lng": 328.06048583984375,
-    "alt": 1756.8802490234375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -1082.681640625,
-        "y": -51505.046875,
-        "z": 1765.0
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton86",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -49890.30078125,
-    "lng": 1214.64306640625,
-    "alt": 3264.0
-  },
-  {
-    "name": "PedestalButton87",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -49268.77734375,
-    "lng": 4080.97265625,
-    "alt": 3260.769287109375
-  },
-  {
-    "name": "PedestalButton88",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -48309.44921875,
-    "lng": 4095.30029296875,
-    "alt": 2694.91015625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 4178.67431640625,
-        "y": -48259.59375,
-        "z": 2764.50732421875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton89_19",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -43057.83203125,
-    "lng": 50447.796875,
-    "alt": 1941.980224609375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 50530.4921875,
-        "y": -43417.90234375,
-        "z": 1953.3919677734375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton8_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 4979.291015625,
-    "lng": 18859.189453125,
-    "alt": 3232.6064453125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 18889.99609375,
-        "y": 4766.80908203125,
-        "z": 3108.076904296875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton90_4",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 10386.400390625,
-    "lng": 32573.740234375,
-    "alt": 4071.34130859375
-  },
-  {
-    "name": "PedestalButton91_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -155.0,
-    "lng": 217.0,
-    "alt": -298.0
-  },
-  {
-    "name": "PedestalButton92_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -36485.0,
-    "lng": 632.0,
-    "alt": 3111.59716796875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 436.35888671875,
-        "y": -38128.97265625,
-        "z": 1774.5968017578125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton93_4",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -37558.0,
-    "lng": 2855.0,
-    "alt": 3233.666748046875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 3065.35888671875,
-        "y": -37456.97265625,
-        "z": 3244.0
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton94",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -25810.671875,
-    "lng": 20131.4453125,
-    "alt": -3019.18310546875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 19997.5859375,
-        "y": -25816.71875,
-        "z": -2945.32275390625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton96",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -187.90432739257812,
-    "lng": 225.0,
-    "alt": -20000.0
-  },
-  {
-    "name": "PedestalButton97_11",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -8513.73046875,
-    "lng": 62258.59375,
-    "alt": 510.9388122558594
-  },
-  {
-    "name": "PedestalButton98_14",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -7831.21533203125,
-    "lng": 62290.76953125,
-    "alt": 3612.359619140625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 62192.71484375,
-        "y": -7916.13720703125,
-        "z": 3742.08544921875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton99_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -288947.0,
-    "lng": 320.0,
-    "alt": 10298.0
-  },
-  {
-    "name": "PedestalButton9_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 7214.5615234375,
-    "lng": 24407.64453125,
-    "alt": 3846.795654296875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 25533.75,
-        "y": 11236.0361328125,
-        "z": 3188.543701171875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": 12455.248046875,
-    "lng": 26913.853515625,
-    "alt": 3011.641845703125
-  },
-  {
-    "name": "PedestalButton_Shape1",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -48930.8203125,
-    "lng": 55093.2265625,
-    "alt": 1880.3564453125
-  },
-  {
-    "name": "PedestalButton_Shape2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -48010.07421875,
-    "lng": 54560.60546875,
-    "alt": 1885.31787109375
-  },
-  {
-    "name": "PedestalButton_Shape3",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Complete",
-    "lat": -48335.8203125,
-    "lng": 54754.0,
-    "alt": 2424.177001953125
-  },
-  {
-    "name": "A1FastTravelPipeCap",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": 15560.884765625,
-    "lng": 20652.861328125,
-    "alt": 3572.840087890625
-  },
-  {
-    "name": "A1FastTravelPipeCap2",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -32586.25390625,
-    "lng": 17408.404296875,
-    "alt": 379.67572021484375
-  },
-  {
-    "name": "A2FastTravelPipeCap",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -7363.88330078125,
-    "lng": 61197.86328125,
-    "alt": 4666.0
-  },
-  {
-    "name": "A2FastTravelPipeCap2",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -32588.25390625,
-    "lng": 17980.796875,
-    "alt": 382.5982666015625
-  },
-  {
-    "name": "A3FastTravelPipeCap",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -43396.73046875,
-    "lng": 8937.830078125,
-    "alt": 2463.414306640625
-  },
-  {
-    "name": "A3FastTravelPipeCap3",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -32586.25390625,
-    "lng": 18539.6328125,
-    "alt": 381.9172668457031
-  },
-  {
-    "name": "A4FastTravelPipeCap",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -60099.109375,
-    "lng": 57716.53125,
-    "alt": 1278.751220703125
-  },
-  {
-    "name": "A4FastTravelPipeCap4",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -32586.25390625,
-    "lng": 19086.947265625,
-    "alt": 380.5115661621094
-  },
-  {
-    "name": "A4SmallWallPipeCap_BeachSide",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -48333.3828125,
-    "lng": 42753.484375,
-    "alt": 1487.4796142578125
-  },
-  {
-    "name": "A4SmallWallPipeCap_CubeSide",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -48088.921875,
-    "lng": 42462.2578125,
-    "alt": -53.9244384765625
-  },
-  {
-    "name": "A5FastTravelPipe_ExitCombatFinale",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -31964.537109375,
-    "lng": 20148.083984375,
-    "alt": 287.7752990722656
-  },
-  {
-    "name": "A5FastTravelPipeCap1",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -42555.07421875,
-    "lng": 21526.291015625,
-    "alt": 3507.08544921875
-  },
-  {
-    "name": "A5FastTravelPipeCap5",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -32586.25390625,
-    "lng": 19641.314453125,
-    "alt": 380.9241027832031
-  },
-  {
-    "name": "PipeCap10_2",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -13410.740234375,
-    "lng": 4797.03271484375,
-    "alt": 2301.41357421875
-  },
-  {
-    "name": "PipeCap13",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -7682.0380859375,
-    "lng": 5404.517578125,
-    "alt": 1181.64208984375
-  },
-  {
-    "name": "PipeCap14",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": 12369.5380859375,
-    "lng": 20962.060546875,
-    "alt": 3910.046875
-  },
-  {
-    "name": "PipeCap2",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -13181.89453125,
-    "lng": 56968.3984375,
-    "alt": 786.9484252929688
-  },
-  {
-    "name": "PipeCap4_2",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -537.02880859375,
-    "lng": 37337.58203125,
-    "alt": 2679.68896484375
-  },
-  {
-    "name": "PipeCap8_2",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -11687.453125,
-    "lng": 32508.5625,
-    "alt": -98.70347595214844
-  },
-  {
-    "name": "PipeCap9_5",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": 13195.0986328125,
-    "lng": 22501.416015625,
-    "alt": 3545.837890625
-  },
-  {
-    "name": "PipeCap_2",
-    "type": "PipeCap_C",
-    "area": "DLC2_Complete",
-    "lat": -14990.53515625,
-    "lng": 58759.33984375,
-    "alt": 790.1314086914062
+    "alt": -42.49445343017578
   },
   {
     "name": "PipesystemNew10",
@@ -15880,8 +10522,8 @@
     "name": "NODE_AddChildActorComponent-1_PipesystemNewDLC_C_CAT_0",
     "type": "PipesystemNewDLC_C",
     "area": "DLC2_Complete",
-    "lat": 12044.2080078125,
-    "lng": 29695.482421875,
+    "lat": 11513.6494140625,
+    "lng": 31008.330078125,
     "alt": 3980.762939453125,
     "notsaved": true
   },
@@ -15889,27 +10531,27 @@
     "name": "NODE_AddChildActorComponent-1_PipesystemNewDLC_C_CAT_1",
     "type": "PipesystemNewDLC_C",
     "area": "DLC2_Complete",
-    "lat": 12564.2890625,
-    "lng": 29449.42578125,
-    "alt": 3980.767333984375,
+    "lat": 11716.74609375,
+    "lng": 31546.642578125,
+    "alt": 3980.762939453125,
     "notsaved": true
   },
   {
     "name": "NODE_AddChildActorComponent-1_PipesystemNewDLC_C_CAT_1943",
     "type": "PipesystemNewDLC_C",
     "area": "DLC2_Complete",
-    "lat": 2852.74658203125,
-    "lng": 20171.46484375,
-    "alt": 2784.47412109375,
+    "lat": 34.67683410644531,
+    "lng": 19214.87890625,
+    "alt": 4812.4736328125,
     "notsaved": true
   },
   {
     "name": "NODE_AddChildActorComponent-1_PipesystemNewDLC_C_CAT_2",
     "type": "PipesystemNewDLC_C",
     "area": "DLC2_Complete",
-    "lat": 14539.12109375,
-    "lng": 30247.51171875,
-    "alt": 3980.779541015625,
+    "lat": 13691.578125,
+    "lng": 32344.7265625,
+    "alt": 3980.750732421875,
     "notsaved": true
   },
   {
@@ -15927,7 +10569,7 @@
     "area": "DLC2_Complete",
     "lat": -36987.99609375,
     "lng": -716.8406982421875,
-    "alt": 3764.000732421875,
+    "alt": 3764.001220703125,
     "notsaved": true
   },
   {
@@ -15936,7 +10578,7 @@
     "area": "DLC2_Complete",
     "lat": -39729.9921875,
     "lng": 1311.1640625,
-    "alt": 2469.000244140625,
+    "alt": 2469.0,
     "notsaved": true
   },
   {
@@ -15945,7 +10587,7 @@
     "area": "DLC2_Complete",
     "lat": -39729.9921875,
     "lng": 105.16413879394531,
-    "alt": 2190.001220703125,
+    "alt": 2190.0009765625,
     "notsaved": true
   },
   {
@@ -15961,9 +10603,9 @@
     "name": "NODE_AddChildActorComponent-1_PipesystemNewDLC_C_CAT_680",
     "type": "PipesystemNewDLC_C",
     "area": "DLC2_Complete",
-    "lat": 1201.297119140625,
-    "lng": 19610.884765625,
-    "alt": 4078.473876953125,
+    "lat": 1686.12646484375,
+    "lng": 19775.458984375,
+    "alt": 3518.473876953125,
     "notsaved": true
   },
   {
@@ -15972,16 +10614,16 @@
     "area": "DLC2_Complete",
     "lat": -37725.99609375,
     "lng": -716.8383178710938,
-    "alt": 3010.000732421875,
+    "alt": 3010.001220703125,
     "notsaved": true
   },
   {
     "name": "NODE_AddChildActorComponent-1_PipesystemNewDLC_C_CAT_79",
     "type": "PipesystemNewDLC_C",
     "area": "DLC2_Complete",
-    "lat": 14541.90234375,
-    "lng": 30248.634765625,
-    "alt": 3980.779541015625,
+    "lat": 13694.359375,
+    "lng": 32345.8515625,
+    "alt": 3980.750732421875,
     "notsaved": true
   },
   {
@@ -16242,9 +10884,9 @@
     "other_pipe": "DLC2_Complete:PipeToAreaBoss2",
     "linetype": "pipe",
     "target": {
-      "x": 20148.083984375,
-      "y": -31964.537109375,
-      "z": 287.7752990722656
+      "x": 20148.087890625,
+      "y": -31964.517578125,
+      "z": 287.7774353027344
     },
     "twoway": 2
   },
@@ -16330,9 +10972,9 @@
     "name": "PipeToAreaBoss2",
     "type": "PipesystemNewDLC_C",
     "area": "DLC2_Complete",
-    "lat": -31964.537109375,
-    "lng": 20148.083984375,
-    "alt": 287.7752990722656,
+    "lat": -31964.517578125,
+    "lng": 20148.087890625,
+    "alt": 287.7774353027344,
     "other_pipe": "DLC2_Complete:PipesystemNewDLC_CombatExitPipe",
     "nearest_cap": "DLC2_Complete:A5FastTravelPipe_ExitCombatFinale",
     "twoway": 1,
@@ -16406,14 +11048,6 @@
     "cost": 100
   },
   {
-    "name": "Purchase_SlumHouse1_2",
-    "type": "Purchase_SlumHouse1_C",
-    "area": "DLC2_Complete",
-    "lat": -28398.265625,
-    "lng": 11155.4501953125,
-    "alt": -148.50311279296875
-  },
-  {
     "name": "Purchase_StonePickaxe_8",
     "type": "Purchase_StonePickaxe_C",
     "area": "DLC2_Complete",
@@ -16430,2666 +11064,6 @@
     "lng": 22349.587890625,
     "alt": 3223.587646484375,
     "cost": 42
-  },
-  {
-    "name": "A2_PipeGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -7691.0,
-    "lng": 61209.0,
-    "alt": 4298.00048828125
-  },
-  {
-    "name": "B1_PipeKeyGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -10198.7783203125,
-    "lng": 57990.6875,
-    "alt": 528.073486328125
-  },
-  {
-    "name": "B3_Roof_RedGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11120.3193359375,
-    "lng": 64930.6640625,
-    "alt": 4129.6455078125
-  },
-  {
-    "name": "B3_Roof_RedGuy3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -46620.49609375,
-    "lng": 6250.435546875,
-    "alt": 3359.1904296875
-  },
-  {
-    "name": "B3_Roof_RedGuyHungry",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -12045.529296875,
-    "lng": 64304.60546875,
-    "alt": 4129.6455078125
-  },
-  {
-    "name": "Baron",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -29673.17578125,
-    "lng": 18533.15625,
-    "alt": 3177.312255859375
-  },
-  {
-    "name": "Baron2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -25311.962890625,
-    "lng": 10556.541015625,
-    "alt": -114.37921905517578
-  },
-  {
-    "name": "Baron3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43243.5625,
-    "lng": 21467.98828125,
-    "alt": 3576.312255859375
-  },
-  {
-    "name": "Baron4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -24883.958984375,
-    "lng": 16379.287109375,
-    "alt": -122.73997497558594
-  },
-  {
-    "name": "Baron5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -29199.423828125,
-    "lng": 18521.73046875,
-    "alt": -26.167572021484375
-  },
-  {
-    "name": "Baron6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -35081.109375,
-    "lng": 20570.55859375,
-    "alt": 3661.9375
-  },
-  {
-    "name": "Baron7",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30256.17578125,
-    "lng": 18490.15625,
-    "alt": -122.76730346679688
-  },
-  {
-    "name": "Baron8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30429.17578125,
-    "lng": 20108.15625,
-    "alt": -91.2581787109375
-  },
-  {
-    "name": "Baron9",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30135.619140625,
-    "lng": 18392.291015625,
-    "alt": 3066.8564453125
-  },
-  {
-    "name": "BaronGoonRamp5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -32854.1875,
-    "lng": 20356.1015625,
-    "alt": 3334.2138671875
-  },
-  {
-    "name": "BaronGoonRamp7",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -24673.90234375,
-    "lng": 16188.28125,
-    "alt": -122.72464752197266
-  },
-  {
-    "name": "BaronGoonRamp8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -24779.486328125,
-    "lng": 16065.037109375,
-    "alt": -98.42057037353516
-  },
-  {
-    "name": "BaronGoonRamp9",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -25407.548828125,
-    "lng": 17541.826171875,
-    "alt": -122.72464752197266
-  },
-  {
-    "name": "BathGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 2096.6845703125,
-    "lng": 10374.72265625,
-    "alt": 3117.1728515625
-  },
-  {
-    "name": "BathGuy2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 2106.230224609375,
-    "lng": 11315.0615234375,
-    "alt": 3175.5654296875,
-    "variant": "red"
-  },
-  {
-    "name": "Beach_Runner_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -57783.828125,
-    "lng": 52986.765625,
-    "alt": 553.03857421875,
-    "variant": "blue"
-  },
-  {
-    "name": "Beach_Runner_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -57591.7421875,
-    "lng": 53127.671875,
-    "alt": 553.0380859375,
-    "variant": "orange"
-  },
-  {
-    "name": "Blacksmith3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28049.404296875,
-    "lng": 16364.93359375,
-    "alt": -122.75139617919922
-  },
-  {
-    "name": "BlindGatekeeper",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21792.033203125,
-    "lng": 18709.78515625,
-    "alt": -122.76642608642578
-  },
-  {
-    "name": "BlindGatekeeper2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -20108.033203125,
-    "lng": 19179.78515625,
-    "alt": 23.23357391357422
-  },
-  {
-    "name": "BlueCollarGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -29647.271484375,
-    "lng": 21500.216796875,
-    "alt": -122.7363510131836
-  },
-  {
-    "name": "BlueInspector1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21657.5625,
-    "lng": -73378.0078125,
-    "alt": 2387.0302734375,
-    "variant": "blue"
-  },
-  {
-    "name": "BlueKing1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21417.609375,
-    "lng": -73336.2265625,
-    "alt": 2369.521484375,
-    "variant": "blue"
-  },
-  {
-    "name": "BluePlumberStatue",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -29104.16015625,
-    "lng": 18488.52734375,
-    "alt": 0.1573333740234375,
-    "variant": "blue"
-  },
-  {
-    "name": "BluePrince1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21873.904296875,
-    "lng": -74015.6328125,
-    "alt": 2369.556640625,
-    "variant": "blue"
-  },
-  {
-    "name": "Constructor2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28960.884765625,
-    "lng": 11522.1875,
-    "alt": -122.71790313720703
-  },
-  {
-    "name": "Constructor3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26325.41015625,
-    "lng": 18754.7734375,
-    "alt": -85.2814712524414
-  },
-  {
-    "name": "Constructor4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30446.0546875,
-    "lng": 18259.384765625,
-    "alt": -122.69763946533203
-  },
-  {
-    "name": "Curtis2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -31445.123046875,
-    "lng": 18040.39453125,
-    "alt": -111.6589126586914
-  },
-  {
-    "name": "CutsceneBaron",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -29673.17578125,
-    "lng": 18629.15625,
-    "alt": 3177.312255859375
-  },
-  {
-    "name": "DirectionGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -25712.0,
-    "lng": 19583.0,
-    "alt": 1438.7535400390625
-  },
-  {
-    "name": "ErniePlumber",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -13095.2490234375,
-    "lng": 52979.77734375,
-    "alt": 560.9467163085938
-  },
-  {
-    "name": "FerniePlumber2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -12978.5625,
-    "lng": 52796.203125,
-    "alt": 520.08837890625
-  },
-  {
-    "name": "Filbert",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -12915.634765625,
-    "lng": 58559.515625,
-    "alt": 1354.4542236328125
-  },
-  {
-    "name": "Historian2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -22726.375,
-    "lng": 21710.57421875,
-    "alt": 3066.934814453125,
-    "variant": "red"
-  },
-  {
-    "name": "Lifeguard",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -57045.7734375,
-    "lng": 49462.5859375,
-    "alt": 553.0389404296875
-  },
-  {
-    "name": "Lifeguard3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -53393.234375,
-    "lng": 54200.62109375,
-    "alt": 553.0387573242188
-  },
-  {
-    "name": "Lifeguard4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -52697.59375,
-    "lng": 52598.03125,
-    "alt": 548.97216796875
-  },
-  {
-    "name": "Lifeguard5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -51678.953125,
-    "lng": 56315.6796875,
-    "alt": 553.0086669921875
-  },
-  {
-    "name": "Magician",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27341.544921875,
-    "lng": 20579.71875,
-    "alt": -74.22403717041016
-  },
-  {
-    "name": "Marius",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -15366.451171875,
-    "lng": 50450.8203125,
-    "alt": 520.767578125
-  },
-  {
-    "name": "MinecraftGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -63389.2890625,
-    "lng": 42216.4140625,
-    "alt": 3283.53271484375,
-    "variant": "red"
-  },
-  {
-    "name": "MinerShopkeeper",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 15385.3466796875,
-    "lng": 22308.671875,
-    "alt": 3263.995361328125
-  },
-  {
-    "name": "MinerShopkeeperKid",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 19588.630859375,
-    "lng": 18493.78515625,
-    "alt": 3195.607421875
-  },
-  {
-    "name": "MinerShopkeeperKid2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 15390.7177734375,
-    "lng": 21924.376953125,
-    "alt": 3195.607421875
-  },
-  {
-    "name": "MonsterAcademic3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30049.00390625,
-    "lng": 18062.931640625,
-    "alt": -100.59821319580078
-  },
-  {
-    "name": "MonsterHunter",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -23183.6640625,
-    "lng": 21225.6328125,
-    "alt": 3061.6328125
-  },
-  {
-    "name": "MrMiracle1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21657.689453125,
-    "lng": -74009.4140625,
-    "alt": 2369.521484375,
-    "variant": "blue"
-  },
-  {
-    "name": "NPC_Bank10",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -47084.359375,
-    "lng": 3602.866455078125,
-    "alt": 1852.000244140625
-  },
-  {
-    "name": "NPC_Bank11",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -47203.73046875,
-    "lng": 3243.4169921875,
-    "alt": 1852.000244140625
-  },
-  {
-    "name": "NPC_Bank12",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -47182.58984375,
-    "lng": 3597.775634765625,
-    "alt": 1852.000244140625
-  },
-  {
-    "name": "NPC_Bank14",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -46517.796875,
-    "lng": 2329.93798828125,
-    "alt": 1852.000244140625
-  },
-  {
-    "name": "NPC_Bank9",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -47055.10546875,
-    "lng": 3226.01220703125,
-    "alt": 1852.000244140625
-  },
-  {
-    "name": "NPC_BankChaos4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -47171.0234375,
-    "lng": 2854.108154296875,
-    "alt": 1852.000244140625
-  },
-  {
-    "name": "NPC_BankChaos5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -47169.96484375,
-    "lng": 3237.6181640625,
-    "alt": 1852.000244140625
-  },
-  {
-    "name": "NPC_BankChaos6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -46900.71484375,
-    "lng": 3249.777099609375,
-    "alt": 1852.000244140625
-  },
-  {
-    "name": "NPC_BankEmployee10",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -52242.1796875,
-    "lng": -988.43212890625,
-    "alt": 1851.805908203125
-  },
-  {
-    "name": "NPC_BankEmployee11",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -48968.79296875,
-    "lng": -156.4736328125,
-    "alt": 1851.805908203125
-  },
-  {
-    "name": "NPC_BankEmployee12",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -50302.11328125,
-    "lng": 1488.1083984375,
-    "alt": 1852.8079833984375
-  },
-  {
-    "name": "NPC_BankEmployee13",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -50349.88671875,
-    "lng": 1653.4287109375,
-    "alt": 1852.8079833984375
-  },
-  {
-    "name": "NPC_BankEmployee14",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -50056.515625,
-    "lng": 1741.3018798828125,
-    "alt": 1852.8079833984375
-  },
-  {
-    "name": "NPC_BankEmployee3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -50375.74609375,
-    "lng": 2695.2783203125,
-    "alt": 1851.805908203125
-  },
-  {
-    "name": "NPC_BankEmployee9",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -51296.5390625,
-    "lng": 2283.19384765625,
-    "alt": 1851.805908203125
-  },
-  {
-    "name": "NPC_BankTeller4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -47407.55078125,
-    "lng": 2851.4423828125,
-    "alt": 1851.8060302734375
-  },
-  {
-    "name": "NPC_BankTeller5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -47408.703125,
-    "lng": 3607.276123046875,
-    "alt": 1851.805908203125
-  },
-  {
-    "name": "NPC_BankTeller6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -47407.55078125,
-    "lng": 3246.104736328125,
-    "alt": 1851.805908203125
-  },
-  {
-    "name": "NPC_BankVaultGuard5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -48559.5546875,
-    "lng": 4046.2939453125,
-    "alt": 1851.805908203125
-  },
-  {
-    "name": "NPC_BankVaultGuard6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -49503.25,
-    "lng": 3850.514404296875,
-    "alt": 1851.805908203125
-  },
-  {
-    "name": "NPC_BankVaultGuard7",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -52316.98046875,
-    "lng": 3817.72607421875,
-    "alt": 1851.805908203125
-  },
-  {
-    "name": "NPC_BankVaultGuard8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -47349.3828125,
-    "lng": 2507.20703125,
-    "alt": 3356.510986328125
-  },
-  {
-    "name": "NPC_Cafe1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -12596.2880859375,
-    "lng": 64335.43359375,
-    "alt": 4129.6494140625
-  },
-  {
-    "name": "NPC_Cafe2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -12416.1298828125,
-    "lng": 64116.921875,
-    "alt": 4142.6494140625
-  },
-  {
-    "name": "NPC_Cafe3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -12009.9296875,
-    "lng": 63621.703125,
-    "alt": 4135.6494140625
-  },
-  {
-    "name": "NPC_Cafe4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11732.39453125,
-    "lng": 63467.859375,
-    "alt": 4129.6494140625
-  },
-  {
-    "name": "NPC_Cafe5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11454.310546875,
-    "lng": 65158.40234375,
-    "alt": 4129.6494140625
-  },
-  {
-    "name": "NPC_Cafe6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11557.91015625,
-    "lng": 65259.2421875,
-    "alt": 4129.6494140625
-  },
-  {
-    "name": "NPC_CageBottom1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -24417.71875,
-    "lng": 17997.181640625,
-    "alt": -98.69355010986328
-  },
-  {
-    "name": "NPC_CageBottom10",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26914.337890625,
-    "lng": 17381.2421875,
-    "alt": -122.7531967163086
-  },
-  {
-    "name": "NPC_CageBottom11",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27737.568359375,
-    "lng": 15398.3369140625,
-    "alt": -124.12955474853516
-  },
-  {
-    "name": "NPC_CageBottom12",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27711.935546875,
-    "lng": 15688.212890625,
-    "alt": -125.70922088623047
-  },
-  {
-    "name": "NPC_CageBottom14",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28867.94921875,
-    "lng": 17621.490234375,
-    "alt": -48.23596954345703
-  },
-  {
-    "name": "NPC_CageBottom16",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28155.265625,
-    "lng": 19330.50390625,
-    "alt": -112.92538452148438
-  },
-  {
-    "name": "NPC_CageBottom17",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30443.509765625,
-    "lng": 15345.3974609375,
-    "alt": -106.14286041259766
-  },
-  {
-    "name": "NPC_CageBottom2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -22742.3828125,
-    "lng": 19448.7734375,
-    "alt": -98.69355010986328
-  },
-  {
-    "name": "NPC_CageBottom20",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30254.94921875,
-    "lng": 18131.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom21",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30539.94921875,
-    "lng": 18045.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom22",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30419.94921875,
-    "lng": 18084.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom23",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30652.94921875,
-    "lng": 17997.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom24",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30093.94921875,
-    "lng": 18354.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom25",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30233.94921875,
-    "lng": 18308.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom26",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30327.94921875,
-    "lng": 18806.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom27",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30504.94921875,
-    "lng": 18806.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom28",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30640.94921875,
-    "lng": 18806.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom29",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30138.94921875,
-    "lng": 17850.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26592.46484375,
-    "lng": 19894.71875,
-    "alt": -98.69355010986328
-  },
-  {
-    "name": "NPC_CageBottom30",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30419.94921875,
-    "lng": 17789.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom31",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30327.94921875,
-    "lng": 19004.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom32",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -29850.94921875,
-    "lng": 18715.490234375,
-    "alt": -122.73005676269531
-  },
-  {
-    "name": "NPC_CageBottom33",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -22957.240234375,
-    "lng": 17494.078125,
-    "alt": -79.55591583251953
-  },
-  {
-    "name": "NPC_CageBottom34",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28084.517578125,
-    "lng": 19618.0859375,
-    "alt": -112.92538452148438
-  },
-  {
-    "name": "NPC_CageBottom35",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -22845.240234375,
-    "lng": 17494.078125,
-    "alt": -79.55591583251953
-  },
-  {
-    "name": "NPC_CageBottom4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26185.99609375,
-    "lng": 17272.61328125,
-    "alt": -122.7531967163086
-  },
-  {
-    "name": "NPC_CageBottom5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26508.76953125,
-    "lng": 19418.259765625,
-    "alt": -64.00480651855469
-  },
-  {
-    "name": "NPC_CageBottom6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26483.03515625,
-    "lng": 19321.58203125,
-    "alt": -66.00421905517578
-  },
-  {
-    "name": "NPC_CageBottom7",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27701.04296875,
-    "lng": 20011.314453125,
-    "alt": -119.63652801513672
-  },
-  {
-    "name": "NPC_CageBottom8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27553.83984375,
-    "lng": 19949.109375,
-    "alt": -112.92538452148438
-  },
-  {
-    "name": "NPC_CageBottom9",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -23210.015625,
-    "lng": 17889.662109375,
-    "alt": -98.69355010986328
-  },
-  {
-    "name": "NPC_CageMiddle10",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -25123.396484375,
-    "lng": 18687.353515625,
-    "alt": 1438.31982421875
-  },
-  {
-    "name": "NPC_CageMiddle11",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -32333.91015625,
-    "lng": 15099.57421875,
-    "alt": 1436.078369140625
-  },
-  {
-    "name": "NPC_CageMiddle12",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -31618.466796875,
-    "lng": 14819.794921875,
-    "alt": 1448.4898681640625
-  },
-  {
-    "name": "NPC_CageMiddle13",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -35865.6640625,
-    "lng": 14379.583984375,
-    "alt": 2180.487548828125
-  },
-  {
-    "name": "NPC_CageMiddle15",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -19512.953125,
-    "lng": 32128.787109375,
-    "alt": -2516.34765625
-  },
-  {
-    "name": "NPC_CageMiddle16",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -29526.1953125,
-    "lng": 24780.58203125,
-    "alt": 1816.2642822265625
-  },
-  {
-    "name": "NPC_CageMiddle2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26675.216796875,
-    "lng": 19734.779296875,
-    "alt": 1438.7744140625
-  },
-  {
-    "name": "NPC_CageMiddle3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -31493.14453125,
-    "lng": 19795.4765625,
-    "alt": 1438.4229736328125
-  },
-  {
-    "name": "NPC_CageMiddle4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -24695.97265625,
-    "lng": 20450.08984375,
-    "alt": 1446.6865234375
-  },
-  {
-    "name": "NPC_CageMiddle5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30354.515625,
-    "lng": 17986.439453125,
-    "alt": 1536.6553955078125
-  },
-  {
-    "name": "NPC_CageMiddle6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30688.6640625,
-    "lng": 18023.583984375,
-    "alt": 1436.078369140625
-  },
-  {
-    "name": "NPC_CageMiddle7",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30503.228515625,
-    "lng": 18198.4296875,
-    "alt": 1437.71875
-  },
-  {
-    "name": "NPC_CageMiddle8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -24634.501953125,
-    "lng": 17327.431640625,
-    "alt": 1438.31982421875
-  },
-  {
-    "name": "NPC_CageMiddle9",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -25123.396484375,
-    "lng": 18525.353515625,
-    "alt": 1438.31982421875
-  },
-  {
-    "name": "NPC_CageUpper1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28978.3984375,
-    "lng": 20241.576171875,
-    "alt": 3056.728271484375
-  },
-  {
-    "name": "NPC_CageUpper2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28832.822265625,
-    "lng": 20241.783203125,
-    "alt": 3056.728271484375
-  },
-  {
-    "name": "NPC_CageUpper3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28641.794921875,
-    "lng": 16131.8671875,
-    "alt": 3056.728271484375
-  },
-  {
-    "name": "NPC_CageUpper4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -25240.21484375,
-    "lng": 18443.08984375,
-    "alt": 3056.728271484375
-  },
-  {
-    "name": "NPC_CageUpperServent1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -31563.3984375,
-    "lng": 16021.2841796875,
-    "alt": 3056.728271484375,
-    "variant": "red"
-  },
-  {
-    "name": "NPC_CageUpperServent2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -24005.361328125,
-    "lng": 18619.27734375,
-    "alt": 3056.728271484375,
-    "variant": "blue"
-  },
-  {
-    "name": "NPC_CageUpperServent3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27620.873046875,
-    "lng": 14923.8369140625,
-    "alt": 3056.728271484375,
-    "variant": "blue"
-  },
-  {
-    "name": "NPC_CageUpperServent4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -29356.240234375,
-    "lng": 21231.349609375,
-    "alt": 3056.728271484375
-  },
-  {
-    "name": "NPC_CageUpperServent5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -31811.71484375,
-    "lng": 19421.84375,
-    "alt": 3061.509765625
-  },
-  {
-    "name": "NPC_CageUpperServent6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -31650.861328125,
-    "lng": 19502.376953125,
-    "alt": 3062.724365234375
-  },
-  {
-    "name": "NPC_CageUpperServent7",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -33163.8671875,
-    "lng": 15197.5400390625,
-    "alt": 3056.728271484375
-  },
-  {
-    "name": "NPC_Child",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -19379.056640625,
-    "lng": 15114.4755859375,
-    "alt": -73.98895263671875
-  },
-  {
-    "name": "NPC_Child2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -19316.52734375,
-    "lng": 14853.9345703125,
-    "alt": -72.20453643798828
-  },
-  {
-    "name": "NPC_CoinNoticer1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27936.90625,
-    "lng": 19816.91796875,
-    "alt": 1438.789794921875
-  },
-  {
-    "name": "NPC_CoinNoticer2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28029.830078125,
-    "lng": 19649.453125,
-    "alt": 1439.0
-  },
-  {
-    "name": "NPC_CoinNoticer3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27838.267578125,
-    "lng": 19552.54296875,
-    "alt": 1438.789794921875
-  },
-  {
-    "name": "NPC_ExitYellowCrystalBld",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11781.0,
-    "lng": 62131.0,
-    "alt": 2914.479248046875
-  },
-  {
-    "name": "NPC_HintGold",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -42544.0859375,
-    "lng": 7867.53125,
-    "alt": 1858.0
-  },
-  {
-    "name": "NPC_HotBalls1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 10819.830078125,
-    "lng": 22377.458984375,
-    "alt": 3193.3251953125
-  },
-  {
-    "name": "NPC_HotBalls2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 9556.193359375,
-    "lng": 19830.607421875,
-    "alt": 3025.5634765625
-  },
-  {
-    "name": "NPC_Outside4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -45340.1328125,
-    "lng": 6764.32568359375,
-    "alt": 1843.2330322265625,
-    "variant": "blue"
-  },
-  {
-    "name": "NPC_Plumbster10",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11958.4521484375,
-    "lng": 63377.765625,
-    "alt": 519.7507934570312
-  },
-  {
-    "name": "NPC_Plumbster11_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -12068.064453125,
-    "lng": 57851.8359375,
-    "alt": 1311.5372314453125
-  },
-  {
-    "name": "NPC_Plumbster13",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -9897.8994140625,
-    "lng": 60837.4609375,
-    "alt": 4343.55029296875
-  },
-  {
-    "name": "NPC_Plumbster14",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -15529.4296875,
-    "lng": 57052.68359375,
-    "alt": 524.3912963867188
-  },
-  {
-    "name": "NPC_Plumbster15_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -17111.98828125,
-    "lng": 51611.91796875,
-    "alt": 558.2920532226562
-  },
-  {
-    "name": "NPC_Plumbster16",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -13631.6005859375,
-    "lng": 54944.0859375,
-    "alt": 524.2527465820312
-  },
-  {
-    "name": "NPC_Plumbster17",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -15365.5693359375,
-    "lng": 63075.48828125,
-    "alt": 1348.9921875
-  },
-  {
-    "name": "NPC_Plumbster18",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -13059.158203125,
-    "lng": 61016.0546875,
-    "alt": 2895.59033203125
-  },
-  {
-    "name": "NPC_Plumbster19",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11986.787109375,
-    "lng": 54930.36328125,
-    "alt": 594.5990600585938
-  },
-  {
-    "name": "NPC_Plumbster2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -13624.9033203125,
-    "lng": 57089.34375,
-    "alt": 557.9920043945312
-  },
-  {
-    "name": "NPC_Plumbster20",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -15198.482421875,
-    "lng": 52160.15625,
-    "alt": 518.9417724609375
-  },
-  {
-    "name": "NPC_Plumbster21",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -8512.4140625,
-    "lng": 59536.0,
-    "alt": 3611.89306640625
-  },
-  {
-    "name": "NPC_Plumbster3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -12145.52734375,
-    "lng": 62768.171875,
-    "alt": 517.04443359375
-  },
-  {
-    "name": "NPC_Plumbster6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -15577.96875,
-    "lng": 57695.3046875,
-    "alt": 2880.78369140625
-  },
-  {
-    "name": "NPC_Plumbster7",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -13785.59765625,
-    "lng": 64213.97265625,
-    "alt": 519.7509765625
-  },
-  {
-    "name": "NPC_Plumbster7-1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -13712.68359375,
-    "lng": 64067.828125,
-    "alt": 519.7509765625
-  },
-  {
-    "name": "NPC_Plumbster7-2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -13841.6083984375,
-    "lng": 64052.59375,
-    "alt": 519.7509765625
-  },
-  {
-    "name": "NPC_Plumbster8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11510.8310546875,
-    "lng": 62711.85546875,
-    "alt": 519.7509765625
-  },
-  {
-    "name": "NPC_Plumbster9",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11771.806640625,
-    "lng": 63408.96875,
-    "alt": 519.7509155273438
-  },
-  {
-    "name": "NPC_RaceGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -16834.91796875,
-    "lng": 62408.2890625,
-    "alt": 502.5706481933594,
-    "variant": "orange"
-  },
-  {
-    "name": "NPC_RedTowner",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -20116.25,
-    "lng": 17582.041015625,
-    "alt": 26.741802215576172,
-    "variant": "red"
-  },
-  {
-    "name": "NPC_RoamingNPCA1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 7571.001953125,
-    "lng": 24640.408203125,
-    "alt": 3195.615966796875
-  },
-  {
-    "name": "NPC_SFX_CLAPPER",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -23903.751953125,
-    "lng": 18348.23828125,
-    "alt": -146.8983917236328
-  },
-  {
-    "name": "NPC_Signpost",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 2373.109375,
-    "lng": 17716.083984375,
-    "alt": 3417.619140625
-  },
-  {
-    "name": "NPC_Signpost2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 3701.768798828125,
-    "lng": 22892.974609375,
-    "alt": 3231.374267578125
-  },
-  {
-    "name": "NPC_Signpost3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 4408.49072265625,
-    "lng": 23052.34375,
-    "alt": 3181.920166015625
-  },
-  {
-    "name": "NPC_SkullGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -14060.6943359375,
-    "lng": 64559.2578125,
-    "alt": 14089.1455078125,
-    "variant": "blue"
-  },
-  {
-    "name": "NPC_Spa",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 2874.979736328125,
-    "lng": 11735.0859375,
-    "alt": 3226.47509765625
-  },
-  {
-    "name": "NPC_StrengthSoldier",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43619.23046875,
-    "lng": -6771.890625,
-    "alt": 2607.050048828125,
-    "variant": "orange"
-  },
-  {
-    "name": "NPC_Stroller",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11092.2607421875,
-    "lng": 17540.962890625,
-    "alt": 3380.074462890625
-  },
-  {
-    "name": "NPC_Stroller2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -11140.23046875,
-    "lng": 17782.599609375,
-    "alt": 3378.0615234375
-  },
-  {
-    "name": "NPC_Stroller3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -13905.9345703125,
-    "lng": 14211.3046875,
-    "alt": 673.8379516601562
-  },
-  {
-    "name": "NPC_VoidGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -23632.5234375,
-    "lng": 37368.1640625,
-    "alt": 519.8539428710938
-  },
-  {
-    "name": "NPCBuilder5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -48518.2421875,
-    "lng": 4971.8212890625,
-    "alt": 3359.1904296875
-  },
-  {
-    "name": "NPCBuilder6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -46915.98046875,
-    "lng": 5333.94189453125,
-    "alt": 3359.1904296875
-  },
-  {
-    "name": "NPCBuilder7",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -49230.76953125,
-    "lng": 1599.643310546875,
-    "alt": 3359.1904296875
-  },
-  {
-    "name": "NPCBuilder8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -50792.26953125,
-    "lng": 2393.989990234375,
-    "alt": 3944.75390625
-  },
-  {
-    "name": "NPCVaultWorker2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -46727.52734375,
-    "lng": 4479.28125,
-    "alt": 1852.01318359375
-  },
-  {
-    "name": "ParanoidGuy2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28757.40625,
-    "lng": 14880.462890625,
-    "alt": -122.76642608642578
-  },
-  {
-    "name": "Prefect",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -23243.517578125,
-    "lng": 20663.220703125,
-    "alt": 1446.66015625
-  },
-  {
-    "name": "Prefect2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -23065.57421875,
-    "lng": 20103.572265625,
-    "alt": 1439.0457763671875
-  },
-  {
-    "name": "RED_RedguyTown1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27307.193359375,
-    "lng": 18238.79296875,
-    "alt": -128.34739685058594,
-    "variant": "red"
-  },
-  {
-    "name": "RED_RedguyTown2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27540.658203125,
-    "lng": 18513.1796875,
-    "alt": -63.63725280761719,
-    "variant": "blue"
-  },
-  {
-    "name": "RED_RedguyTown3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27314.880859375,
-    "lng": 18690.044921875,
-    "alt": -123.12044525146484,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy103",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43309.56640625,
-    "lng": 6569.68212890625,
-    "alt": 1848.9552001953125
-  },
-  {
-    "name": "RedGuy104_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -37798.484375,
-    "lng": 460.8680419921875,
-    "alt": 1856.648681640625
-  },
-  {
-    "name": "RedGuy105_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -12326.0927734375,
-    "lng": 55707.73046875,
-    "alt": 1348.6287841796875
-  },
-  {
-    "name": "RedGuy106_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -20878.015625,
-    "lng": -66793.6328125,
-    "alt": 8965.0869140625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy107_5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -57932.125,
-    "lng": 56988.3671875,
-    "alt": 4846.9326171875
-  },
-  {
-    "name": "RedGuy108_8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30415.0,
-    "lng": 24947.0,
-    "alt": 2045.0
-  },
-  {
-    "name": "RedGuy109_11",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -30294.8671875,
-    "lng": 25180.337890625,
-    "alt": 1959.289306640625
-  },
-  {
-    "name": "RedGuy110",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -13517.6689453125,
-    "lng": 59780.26953125,
-    "alt": 1348.910888671875
-  },
-  {
-    "name": "RedGuy111",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -39276.94140625,
-    "lng": 3958.540771484375,
-    "alt": 1843.2269287109375
-  },
-  {
-    "name": "RedGuy11_Gold_Lift",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43913.1171875,
-    "lng": 21331.90234375,
-    "alt": 3039.759521484375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy11_Gold_Lift2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44577.0625,
-    "lng": 19764.46484375,
-    "alt": 3039.759521484375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy11_Gold_Lift3_4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21988.83203125,
-    "lng": -73632.4765625,
-    "alt": 2369.537109375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy11_Gold_Lift4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -23100.7890625,
-    "lng": -66268.6015625,
-    "alt": 8861.728515625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy13",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -32369.48046875,
-    "lng": 18717.83203125,
-    "alt": 1448.8953857421875
-  },
-  {
-    "name": "RedGuy13_Building_Lift",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43856.5859375,
-    "lng": 20969.384765625,
-    "alt": 3058.4189453125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy13_Building_Lift2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44582.64453125,
-    "lng": 20039.37890625,
-    "alt": 3058.4189453125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy13_Building_Lift3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -41280.4609375,
-    "lng": 21643.056640625,
-    "alt": 3149.893798828125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy14_Fire_Lift",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43768.9609375,
-    "lng": 21157.44921875,
-    "alt": 3039.7412109375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy14_Fire_Lift2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -41320.87109375,
-    "lng": 21411.931640625,
-    "alt": 3130.23974609375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy14_Smell_Lift2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43938.9609375,
-    "lng": 19847.44921875,
-    "alt": 3039.7412109375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy16_Upper_Lift",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44063.49609375,
-    "lng": 21058.24609375,
-    "alt": 3041.49462890625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy16_Upper_Lift2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44146.12890625,
-    "lng": 19446.87890625,
-    "alt": 3041.49462890625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy16_Upper_Lift3_5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21475.291015625,
-    "lng": -73783.5390625,
-    "alt": 2371.2724609375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy16_Upper_Lift4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21340.783203125,
-    "lng": -66093.6015625,
-    "alt": 8858.462890625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy17_Lower_Lift",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43804.01953125,
-    "lng": 20775.080078125,
-    "alt": 3039.7763671875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy17_Lower_Lift2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44613.54296875,
-    "lng": 19563.05859375,
-    "alt": 3039.7763671875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy17_Lower_Lift3_6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21954.232421875,
-    "lng": -73834.1953125,
-    "alt": 2369.556640625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy17_Lower_Lift4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -23409.7734375,
-    "lng": -66337.6015625,
-    "alt": 8869.654296875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy18_Lava_Lift",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44089.1796875,
-    "lng": 20635.88671875,
-    "alt": 3039.741455078125,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy18_Lava_Lift2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44529.1796875,
-    "lng": 19345.88671875,
-    "alt": 3039.741455078125,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy18_Lava_Lift3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -41508.3515625,
-    "lng": 21090.529296875,
-    "alt": 3059.62109375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy19_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27420.931640625,
-    "lng": 16150.794921875,
-    "alt": -94.25377655029297
-  },
-  {
-    "name": "RedGuy2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43219.91796875,
-    "lng": 21361.576171875,
-    "alt": 3057.251953125,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy20_3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21492.5546875,
-    "lng": 15487.3125,
-    "alt": -122.03857421875
-  },
-  {
-    "name": "RedGuy20_Fat_Lift",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43524.69921875,
-    "lng": 20852.0625,
-    "alt": 3039.764404296875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy20_Fat_Lift2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44369.5078125,
-    "lng": 19636.3828125,
-    "alt": 3039.764404296875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy20_Fat_Lift3_7",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21749.974609375,
-    "lng": -73681.8203125,
-    "alt": 2369.544921875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy20_Fat_Lift4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21610.79296875,
-    "lng": -66173.6015625,
-    "alt": 8822.693359375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy21",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44178.734375,
-    "lng": 19890.2421875,
-    "alt": 3057.251953125,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy21_Fat3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -48589.5703125,
-    "lng": -351.1117248535156,
-    "alt": 3353.04736328125
-  },
-  {
-    "name": "RedGuy21_Fat4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -46736.6015625,
-    "lng": -1430.7313232421875,
-    "alt": 3353.9755859375
-  },
-  {
-    "name": "RedGuy25",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21566.984375,
-    "lng": 15678.9619140625,
-    "alt": -119.53765106201172
-  },
-  {
-    "name": "RedGuy26",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21519.931640625,
-    "lng": 20090.6953125,
-    "alt": -103.12196350097656
-  },
-  {
-    "name": "RedGuy27",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -54527.11328125,
-    "lng": 48303.609375,
-    "alt": 51.2276611328125
-  },
-  {
-    "name": "RedGuy28",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21287.51171875,
-    "lng": 20275.01171875,
-    "alt": -83.96723937988281
-  },
-  {
-    "name": "RedGuy29",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -54898.953125,
-    "lng": 55141.91015625,
-    "alt": 3600.60498046875
-  },
-  {
-    "name": "RedGuy2Counter",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43408.1484375,
-    "lng": 20398.392578125,
-    "alt": 3039.772216796875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy2Counter2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44419.0546875,
-    "lng": 19915.419921875,
-    "alt": 3039.772216796875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy30",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -55148.04296875,
-    "lng": 55465.51953125,
-    "alt": 3592.66748046875
-  },
-  {
-    "name": "RedGuy31",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -18039.75390625,
-    "lng": 19726.451171875,
-    "alt": -174.6399383544922
-  },
-  {
-    "name": "RedGuy32",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -54856.19921875,
-    "lng": 47750.8828125,
-    "alt": 33.6943473815918
-  },
-  {
-    "name": "RedGuy33",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -50166.0234375,
-    "lng": 39259.44921875,
-    "alt": -433.5423583984375
-  },
-  {
-    "name": "RedGuy34",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -50126.78125,
-    "lng": 39375.75390625,
-    "alt": -412.04638671875
-  },
-  {
-    "name": "RedGuy35",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -50058.7265625,
-    "lng": 39428.28515625,
-    "alt": -412.04638671875
-  },
-  {
-    "name": "RedGuy36",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -55836.28125,
-    "lng": 49739.25,
-    "alt": 439.08673095703125
-  },
-  {
-    "name": "RedGuy37",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -55759.62109375,
-    "lng": 49835.12109375,
-    "alt": 441.82977294921875
-  },
-  {
-    "name": "RedGuy38",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -55677.703125,
-    "lng": 49861.203125,
-    "alt": 433.7386474609375
-  },
-  {
-    "name": "RedGuy42",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -13228.802734375,
-    "lng": -56254.1328125,
-    "alt": 8088.3583984375
-  },
-  {
-    "name": "RedGuy57_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 16616.87890625,
-    "lng": 22968.3359375,
-    "alt": 3908.0
-  },
-  {
-    "name": "RedGuy59_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44592.05859375,
-    "lng": 20589.01171875,
-    "alt": 3039.740234375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy60",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44557.0703125,
-    "lng": 20922.76953125,
-    "alt": 3042.29052734375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy61",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44606.9375,
-    "lng": 21367.982421875,
-    "alt": 3042.29052734375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy62",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21722.564453125,
-    "lng": 23462.904296875,
-    "alt": -355.2057800292969
-  },
-  {
-    "name": "RedGuy63_5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21593.876953125,
-    "lng": 23634.513671875,
-    "alt": -358.6994323730469
-  },
-  {
-    "name": "RedGuy64",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -42915.6796875,
-    "lng": 21033.41015625,
-    "alt": 3057.251953125,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy65_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43077.3203125,
-    "lng": 3818.2763671875,
-    "alt": 1858.0,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy66_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -8510.732421875,
-    "lng": -47102.96484375,
-    "alt": 8437.408203125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy67_5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -25751.4609375,
-    "lng": 23301.650390625,
-    "alt": -82.83036041259766
-  },
-  {
-    "name": "RedGuy68_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -40467.0,
-    "lng": 293.0,
-    "alt": 1865.0501708984375
-  },
-  {
-    "name": "RedGuy69_5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -18873.6875,
-    "lng": 13740.25,
-    "alt": 2692.137451171875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy70_6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44396.0,
-    "lng": 19293.0,
-    "alt": 3050.0,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy71",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44500.7734375,
-    "lng": 21421.779296875,
-    "alt": 3042.29052734375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy72",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44239.28125,
-    "lng": 21634.009765625,
-    "alt": 3042.29052734375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy73",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43712.13671875,
-    "lng": 21704.134765625,
-    "alt": 3093.29052734375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy74_10",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43353.0,
-    "lng": 20136.0,
-    "alt": 3040.0,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy75",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44600.21484375,
-    "lng": 21137.30078125,
-    "alt": 3045.29052734375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy76",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -42914.3203125,
-    "lng": 21485.916015625,
-    "alt": 3058.51904296875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy77",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -45092.125,
-    "lng": 19123.41796875,
-    "alt": 3198.068603515625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy78",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44589.39453125,
-    "lng": 21464.38671875,
-    "alt": 3042.29052734375,
-    "variant": "purple"
-  },
-  {
-    "name": "RedGuy79",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44674.58203125,
-    "lng": 20785.83984375,
-    "alt": 3042.29052734375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy80",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44550.625,
-    "lng": 21539.3125,
-    "alt": 3026.5390625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy81",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44028.0078125,
-    "lng": 21927.32421875,
-    "alt": 3146.0224609375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy82",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43210.2421875,
-    "lng": 20103.146484375,
-    "alt": 3040.0,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy83",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43003.9453125,
-    "lng": 20362.5703125,
-    "alt": 3040.0,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy84",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -42484.45703125,
-    "lng": 20680.162109375,
-    "alt": 3058.539306640625,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy85_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -23878.0,
-    "lng": 16690.0,
-    "alt": 447.0
-  },
-  {
-    "name": "RedGuy89_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43834.078125,
-    "lng": 21475.462890625,
-    "alt": 3053.35693359375
-  },
-  {
-    "name": "RedGuy8_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -32364.361328125,
-    "lng": 18597.47265625,
-    "alt": 1448.8953857421875
-  },
-  {
-    "name": "RedGuy90",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43611.078125,
-    "lng": 21992.462890625,
-    "alt": 3550.954833984375
-  },
-  {
-    "name": "RedGuy91",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44076.078125,
-    "lng": 21222.462890625,
-    "alt": 3053.35693359375
-  },
-  {
-    "name": "RedGuy92",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44341.078125,
-    "lng": 21088.462890625,
-    "alt": 3035.35693359375
-  },
-  {
-    "name": "RedGuy93_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -31427.771484375,
-    "lng": 19918.318359375,
-    "alt": -108.29446411132812
-  },
-  {
-    "name": "RedGuy94",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -18224.203125,
-    "lng": -58356.34375,
-    "alt": 8188.1416015625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy95",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -18169.16015625,
-    "lng": -58451.96875,
-    "alt": 8192.880859375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy96_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -45132.0703125,
-    "lng": 49565.30078125,
-    "alt": 2007.4464111328125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy97",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -45316.0703125,
-    "lng": 49653.30078125,
-    "alt": 2007.4464111328125,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy99_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -34549.54296875,
-    "lng": -59309.51171875,
-    "alt": 18544.859375
-  },
-  {
-    "name": "RedGuy9_TransPuzzleLift",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -57084.87890625,
-    "lng": 22403.16796875,
-    "alt": 12057.4423828125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy9_TransPuzzleLift2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -44168.609375,
-    "lng": 19255.53515625,
-    "alt": 3040.6591796875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy9_TransPuzzleLift3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -41274.234375,
-    "lng": 21199.08203125,
-    "alt": 3081.704345703125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy_Building2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -16620.79296875,
-    "lng": 58684.8671875,
-    "alt": 572.3291015625
-  },
-  {
-    "name": "RedGuy_Building4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -8308.7548828125,
-    "lng": 62080.8828125,
-    "alt": 595.7605590820312
-  },
-  {
-    "name": "RedGuy_UndergroundArena_KeyGiver",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": 2147.125,
-    "lng": -58580.00390625,
-    "alt": 8345.369140625,
-    "variant": "red"
-  },
-  {
-    "name": "RedInspector1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21891.65234375,
-    "lng": -73435.6328125,
-    "alt": 2369.552734375,
-    "variant": "red"
-  },
-  {
-    "name": "RedKing1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -21430.955078125,
-    "lng": -73970.9765625,
-    "alt": 2370.439453125,
-    "variant": "red"
-  },
-  {
-    "name": "RedQueen1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -22088.08203125,
-    "lng": -73376.0078125,
-    "alt": 2388.197265625,
-    "variant": "red"
-  },
-  {
-    "name": "RoamingNPC1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -9595.462890625,
-    "lng": 62911.99609375,
-    "alt": 526.336669921875
-  },
-  {
-    "name": "RoamingNPC2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -12311.0361328125,
-    "lng": 61414.8046875,
-    "alt": 535.82080078125
-  },
-  {
-    "name": "RoamingNPC3_Jogger",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -10005.7421875,
-    "lng": 59084.1171875,
-    "alt": 511.6989440917969
-  },
-  {
-    "name": "RobBoss",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -43935.44140625,
-    "lng": 7335.30078125,
-    "alt": 1843.0
-  },
-  {
-    "name": "Shopkeeper",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27456.490234375,
-    "lng": 15478.0849609375,
-    "alt": -95.50179290771484
-  },
-  {
-    "name": "ShopKid1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -25831.802734375,
-    "lng": 21927.234375,
-    "alt": -136.18455505371094
-  },
-  {
-    "name": "ShopKid2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -32422.802734375,
-    "lng": 16747.234375,
-    "alt": 1445.0679931640625
-  },
-  {
-    "name": "Slumguy1_H3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27731.783203125,
-    "lng": 12962.2626953125,
-    "alt": -124.02533721923828
-  },
-  {
-    "name": "Slumguy2_H2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28239.900390625,
-    "lng": 11950.0205078125,
-    "alt": -122.76642608642578
-  },
-  {
-    "name": "Slumguy3_H1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27558.1640625,
-    "lng": 10767.982421875,
-    "alt": -122.66117095947266
-  },
-  {
-    "name": "Slumguy5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -20277.615234375,
-    "lng": 13282.3916015625,
-    "alt": -95.71260833740234
-  },
-  {
-    "name": "Slumguy9_H4_Brother",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26968.861328125,
-    "lng": 12588.7333984375,
-    "alt": -190.48895263671875
-  },
-  {
-    "name": "SlumguyGatekeeper",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -22173.98046875,
-    "lng": 13454.3515625,
-    "alt": -122.76642608642578
-  },
-  {
-    "name": "SlumguyHouse4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26697.376953125,
-    "lng": 12400.642578125,
-    "alt": -156.64352416992188
-  },
-  {
-    "name": "SlumguyHouse5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -20548.376953125,
-    "lng": 13750.642578125,
-    "alt": -122.69598388671875
-  },
-  {
-    "name": "SlumguyLeader",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28310.451171875,
-    "lng": 11074.158203125,
-    "alt": -122.69683074951172
-  },
-  {
-    "name": "SlumguyLeader2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -28310.451171875,
-    "lng": 11074.158203125,
-    "alt": -122.69683074951172
-  },
-  {
-    "name": "SpectatorKid1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27161.521484375,
-    "lng": 20382.94140625,
-    "alt": -157.99583435058594
-  },
-  {
-    "name": "SpectatorKid2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27057.798828125,
-    "lng": 20360.84375,
-    "alt": -157.99244689941406
-  },
-  {
-    "name": "SpectatorKid3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -27042.841796875,
-    "lng": 20458.529296875,
-    "alt": -149.1684112548828
-  },
-  {
-    "name": "SpectatorKid4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26981.24609375,
-    "lng": 20551.978515625,
-    "alt": -149.1684112548828
-  },
-  {
-    "name": "SpectatorKid5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26853.78515625,
-    "lng": 20559.865234375,
-    "alt": -157.9923553466797
-  },
-  {
-    "name": "Vicky_PipeObsessed",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -7067.2705078125,
-    "lng": 60496.828125,
-    "alt": 4135.58447265625
-  },
-  {
-    "name": "WhiteCollarGal",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -26247.111328125,
-    "lng": 20973.39453125,
-    "alt": 1446.6865234375
-  },
-  {
-    "name": "WomanBeach",
-    "type": "RedGuy_C",
-    "area": "DLC2_Complete",
-    "lat": -57269.328125,
-    "lng": 49842.7421875,
-    "alt": 553.0389404296875
   },
   {
     "name": "RespawnActor11_2",
@@ -19865,14 +11839,6 @@
     "alt": 5646.2880859375
   },
   {
-    "name": "SlumBurningQuest_3",
-    "type": "SlumBurningQuest_C",
-    "area": "DLC2_Complete",
-    "lat": -27745.974609375,
-    "lng": 12236.783203125,
-    "alt": -20.975341796875
-  },
-  {
     "name": "Sponge_Large2_4",
     "type": "Sponge_Large_C",
     "area": "DLC2_Complete",
@@ -19881,293 +11847,13 @@
     "alt": 1026.4268798828125
   },
   {
-    "name": "SwingingDoor2_2",
-    "type": "SwingingDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -41548.0,
-    "lng": -155.671875,
-    "alt": 2381.0
-  },
-  {
-    "name": "SwingingDoor3_5",
-    "type": "SwingingDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -11502.7353515625,
-    "lng": 40107.0,
-    "alt": 1852.0
-  },
-  {
-    "name": "SwingingDoor4",
-    "type": "SwingingDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -13833.650390625,
-    "lng": 42156.8125,
-    "alt": 3303.96728515625
-  },
-  {
-    "name": "SwingingDoor5",
-    "type": "SwingingDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -30597.796875,
-    "lng": 18463.0703125,
-    "alt": -2613.29443359375
-  },
-  {
-    "name": "SwingingDoor6",
-    "type": "SwingingDoor_C",
-    "area": "DLC2_Complete",
-    "lat": -47276.70703125,
-    "lng": 2262.790283203125,
-    "alt": 2057.471435546875
-  },
-  {
-    "name": "Mean_TalkingSpeaker14",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -7916.13720703125,
-    "lng": 62192.71484375,
-    "alt": 3742.08544921875
-  },
-  {
-    "name": "Mean_TalkingSpeaker3",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -15842.7470703125,
-    "lng": 46627.10546875,
-    "alt": 516.7955932617188
-  },
-  {
-    "name": "Mean_TalkingSpeaker9",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -16466.865234375,
-    "lng": 58639.0859375,
-    "alt": 3066.939697265625
-  },
-  {
-    "name": "Nice_TalkingSpeaker4",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -16503.5390625,
-    "lng": 46679.5859375,
-    "alt": 522.4327392578125
-  },
-  {
-    "name": "TalkingSpeaker10",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -47331.4765625,
-    "lng": 6315.63623046875,
-    "alt": 2949.21484375
-  },
-  {
-    "name": "TalkingSpeaker11",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -55986.9296875,
-    "lng": 59236.8203125,
-    "alt": 911.9866333007812
-  },
-  {
-    "name": "TalkingSpeaker12",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": 5215.0546875,
-    "lng": 35109.37890625,
-    "alt": 3182.6376953125
-  },
-  {
-    "name": "TalkingSpeaker13",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -14859.986328125,
-    "lng": -57558.7890625,
-    "alt": 10512.35546875
-  },
-  {
-    "name": "TalkingSpeaker14",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -57091.94921875,
-    "lng": 48708.00390625,
-    "alt": 526.9684448242188
-  },
-  {
-    "name": "TalkingSpeaker15_2",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -46501.18359375,
-    "lng": 45798.93359375,
-    "alt": 872.0499267578125
-  },
-  {
-    "name": "TalkingSpeaker16_2",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": 1770.4073486328125,
-    "lng": -12908.90625,
-    "alt": 1023.5304565429688
-  },
-  {
-    "name": "TalkingSpeaker2_2",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -42379.76953125,
-    "lng": 3936.42822265625,
-    "alt": 1856.623779296875
-  },
-  {
-    "name": "TalkingSpeaker3",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -46668.3515625,
-    "lng": 39598.875,
-    "alt": 2274.641357421875
-  },
-  {
-    "name": "TalkingSpeaker4",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -12764.7265625,
-    "lng": 53037.29296875,
-    "alt": 594.500732421875
-  },
-  {
-    "name": "TalkingSpeaker5",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -50859.2421875,
-    "lng": 56357.4453125,
-    "alt": 526.9684448242188
-  },
-  {
-    "name": "TalkingSpeaker6",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -13303.1826171875,
-    "lng": 52741.0234375,
-    "alt": 594.500732421875
-  },
-  {
-    "name": "TalkingSpeaker7_2",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -31324.669921875,
-    "lng": 19618.078125,
-    "alt": -94.01608276367188
-  },
-  {
-    "name": "TalkingSpeaker8",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -31363.41796875,
-    "lng": 19537.36328125,
-    "alt": 1353.5206298828125
-  },
-  {
-    "name": "TalkingSpeaker9",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -49738.95703125,
-    "lng": 35244.171875,
-    "alt": -196.0211181640625
-  },
-  {
-    "name": "TalkingSpeaker_2",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Complete",
-    "lat": -16967.123046875,
-    "lng": 60380.48828125,
-    "alt": 1215.1781005859375
-  },
-  {
-    "name": "Trash2_2",
-    "type": "Trash_C",
-    "area": "DLC2_Complete",
-    "lat": -32357.982421875,
-    "lng": 13619.2890625,
-    "alt": -503.3927307128906
-  },
-  {
-    "name": "Trash3",
-    "type": "Trash_C",
-    "area": "DLC2_Complete",
-    "lat": -31613.896484375,
-    "lng": 13068.78515625,
-    "alt": -414.7896423339844
-  },
-  {
-    "name": "Trash8",
-    "type": "Trash_C",
-    "area": "DLC2_Complete",
-    "lat": -32076.197265625,
-    "lng": 13657.716796875,
-    "alt": -470.2211608886719
-  },
-  {
-    "name": "Trash9",
-    "type": "Trash_C",
-    "area": "DLC2_Complete",
-    "lat": -22030.775390625,
-    "lng": 12210.888671875,
-    "alt": -166.61416625976562
-  },
-  {
-    "name": "Trash_2",
-    "type": "Trash_C",
-    "area": "DLC2_Complete",
-    "lat": -55804.57421875,
-    "lng": 55024.22265625,
-    "alt": 1014.994140625
-  },
-  {
-    "name": "TriggerVolume2_2",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -48014.55078125,
-    "lng": 46237.46875,
-    "alt": 461.9168701171875
-  },
-  {
-    "name": "TriggerVolume3",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -48841.734375,
-    "lng": 45239.5,
-    "alt": 586.6885986328125
-  },
-  {
-    "name": "TriggerVolume8_2",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": 23447.5234375,
-    "lng": 15738.8271484375,
-    "alt": 4141.74169921875
-  },
-  {
-    "name": "TriggerVolume_2",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Complete",
-    "lat": -56294.7265625,
-    "lng": 55762.9765625,
-    "alt": 5755.57666015625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 55670.5859375,
-        "y": -55967.0703125,
-        "z": 5635.62548828125
-      }
-    ]
-  },
-  {
     "name": "MinecraftBrick_GEN_VARIABLE_ValveCarriable_C_CAT_424",
     "type": "ValveCarriable_C",
     "area": "DLC2_Complete",
     "lat": -16200.4560546875,
     "lng": 59717.27734375,
     "alt": 3980.403564453125,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "MinecraftBrick_GEN_VARIABLE_ValveCarriable_C_CAT_426",
@@ -20176,43 +11862,43 @@
     "lat": -12756.4208984375,
     "lng": 65203.9609375,
     "alt": 3278.85791015625,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "MinecraftBrick_GEN_VARIABLE_ValveCarriable_C_CAT_428",
     "type": "ValveCarriable_C",
     "area": "DLC2_Complete",
     "lat": -13849.5703125,
-    "lng": 61255.49609375,
+    "lng": 61215.49609375,
     "alt": 10265.8046875,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "MinecraftBrick_GEN_VARIABLE_ValveCarriable_C_CAT_430",
     "type": "ValveCarriable_C",
     "area": "DLC2_Complete",
-    "lat": -10266.8232421875,
-    "lng": 57378.828125,
+    "lat": -10295.1064453125,
+    "lng": 57407.109375,
     "alt": 726.0514526367188,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "MinecraftBrick_GEN_VARIABLE_ValveCarriable_C_CAT_432",
     "type": "ValveCarriable_C",
     "area": "DLC2_Complete",
-    "lat": -11364.00390625,
-    "lng": 56679.44921875,
+    "lat": -11392.287109375,
+    "lng": 56651.16015625,
     "alt": 1848.478271484375,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "MinecraftBrick_GEN_VARIABLE_ValveCarriable_C_CAT_471",
     "type": "ValveCarriable_C",
     "area": "DLC2_Complete",
-    "lat": -7507.99462890625,
-    "lng": 61151.1640625,
+    "lat": -7479.71240234375,
+    "lng": 61179.453125,
     "alt": 3815.596923828125,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "MinecraftBrick_GEN_VARIABLE_ValveCarriable_C_CAT_560",
@@ -20221,7 +11907,7 @@
     "lat": -6826.0,
     "lng": 59955.0,
     "alt": 4196.00048828125,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "ValveCarriable4",
@@ -20230,7 +11916,7 @@
     "lat": -10631.638671875,
     "lng": 62274.234375,
     "alt": 443.014404296875,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "ValveCarriable_1976",
@@ -20239,210 +11925,7 @@
     "lat": -15603.2978515625,
     "lng": 61870.984375,
     "alt": 430.830322265625,
-    "variant": "purple"
-  },
-  {
-    "name": "BallButton2_2",
-    "type": "BallButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -17967.357421875,
-    "lng": -25541.939453125,
-    "alt": 8055.8974609375
-  },
-  {
-    "name": "BossPuzzle3_BallButton",
-    "type": "BallButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -25030.71875,
-    "lng": -23943.265625,
-    "alt": 7218.1044921875
-  },
-  {
-    "name": "BP_TriggerVolume_2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -22798.4296875,
-    "lng": -31422.17578125,
-    "alt": 5443.0
-  },
-  {
-    "name": "BP_TriggerVolume_ApprachMusic",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -20129.955078125,
-    "lng": -28737.390625,
-    "alt": 6408.06201171875
-  },
-  {
-    "name": "BP_TriggerVolume_BaronTalk1",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -11726.5595703125,
-    "lng": -4168.5302734375,
-    "alt": 1891.0
-  },
-  {
-    "name": "BP_TriggerVolume_BaronTalk2_0",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -11416.9765625,
-    "lng": -6458.5009765625,
-    "alt": 1891.0
-  },
-  {
-    "name": "BP_TriggerVolume_BaronTalk3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -21343.724609375,
-    "lng": -17055.904296875,
-    "alt": 3981.0
-  },
-  {
-    "name": "BP_TriggerVolume_BaronTalk4",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -13444.9560546875,
-    "lng": -21540.11328125,
-    "alt": 3981.0
-  },
-  {
-    "name": "BP_TriggerVolume_BaronTalk5",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -19076.556640625,
-    "lng": -22873.052734375,
-    "alt": 5854.77490234375
-  },
-  {
-    "name": "BP_TriggerVolume_BaronTalk6",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -20799.48046875,
-    "lng": -26733.96875,
-    "alt": 6631.36376953125
-  },
-  {
-    "name": "BP_TriggerVolume_BossArea_ChangeWinds1",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -25389.171875,
-    "lng": -39272.3125,
-    "alt": 12996.8671875
-  },
-  {
-    "name": "BP_TriggerVolume_BossArea_ChangeWinds2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -19165.376953125,
-    "lng": -36537.56640625,
-    "alt": 12996.9384765625
-  },
-  {
-    "name": "BP_TriggerVolume_BossArea_ChangeWinds3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24412.51953125,
-    "lng": -34090.3984375,
-    "alt": 12606.06640625
-  },
-  {
-    "name": "BP_TriggerVolume_SetBossSun1",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -12254.5322265625,
-    "lng": -5474.75830078125,
-    "alt": 1665.0
-  },
-  {
-    "name": "BP_TriggerVolume_SetBossSun2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -19134.716796875,
-    "lng": -20226.529296875,
-    "alt": 5465.0
-  },
-  {
-    "name": "BP_TriggerVolume_SetBossSun3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -22099.94921875,
-    "lng": -29756.30859375,
-    "alt": 6895.0
-  },
-  {
-    "name": "Trigger_PlayerOutSideBoss-CheckIfDoorShouldBeOpen",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -18103.82421875,
-    "lng": -20881.587890625,
-    "alt": 4866.34521484375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -23642.3984375,
-        "y": -21571.9375,
-        "z": 5995.0
-      },
-      {
-        "x": -25358.8046875,
-        "y": -18835.640625,
-        "z": 5995.0
-      },
-      {
-        "x": -28787.82421875,
-        "y": -19954.9765625,
-        "z": 6395.0
-      },
-      {
-        "x": -24345.373046875,
-        "y": -21534.421875,
-        "z": 6030.90771484375
-      },
-      {
-        "x": -27882.685546875,
-        "y": -20051.919921875,
-        "z": 5995.0
-      },
-      {
-        "x": -30054.828125,
-        "y": -20071.126953125,
-        "z": 7161.45068359375
-      }
-    ]
-  },
-  {
-    "name": "BossPuzzle0_ButtonFloor",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -20417.4140625,
-    "lng": -29262.650390625,
-    "alt": 6795.0,
-    "variant": "yellow",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -27882.685546875,
-        "y": -20051.919921875,
-        "z": 5995.0
-      }
-    ]
-  },
-  {
-    "name": "BossPuzzle3_ButtonFloor",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24898.080078125,
-    "lng": -23653.373046875,
-    "alt": 7199.80517578125,
-    "variant": "yellow"
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_224",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -18616.083984375,
-    "lng": -26558.501953125,
-    "alt": 6096.26025390625
+    "variant": "red"
   },
   {
     "name": "Chest2_2",
@@ -20490,78 +11973,6 @@
     "coins": 1
   },
   {
-    "name": "BossPuzzle0_Door1",
-    "type": "DoorInverted_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -19954.9765625,
-    "lng": -28787.82421875,
-    "alt": 6395.0
-  },
-  {
-    "name": "BossPuzzle0_Door2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -20051.919921875,
-    "lng": -27882.685546875,
-    "alt": 5995.0
-  },
-  {
-    "name": "BossPuzzle1_Door",
-    "type": "DoorInverted_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -18835.640625,
-    "lng": -25358.8046875,
-    "alt": 5995.0
-  },
-  {
-    "name": "BossPuzzle2_Door1",
-    "type": "DoorInverted_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -21571.9375,
-    "lng": -23642.3984375,
-    "alt": 5995.0
-  },
-  {
-    "name": "BossPuzzle2_Door2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -21534.421875,
-    "lng": -24345.373046875,
-    "alt": 6030.90771484375
-  },
-  {
-    "name": "BossPuzzle2_Door3",
-    "type": "DoorInverted_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -21907.14453125,
-    "lng": -25213.55078125,
-    "alt": 5995.0
-  },
-  {
-    "name": "BossPuzzle3_JailDoor1",
-    "type": "DoorInverted_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -23358.244140625,
-    "lng": -25899.34765625,
-    "alt": 7195.0
-  },
-  {
-    "name": "BossPuzzle3_JailDoor2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24083.291015625,
-    "lng": -25561.251953125,
-    "alt": 7195.0
-  },
-  {
-    "name": "BossPuzzle3_JailDoor3",
-    "type": "DoorInverted_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24807.91796875,
-    "lng": -25222.259765625,
-    "alt": 7195.0
-  },
-  {
     "name": "BossPuzzle3_ExplodingBattery",
     "type": "ExplodingBattery_C",
     "area": "DLC2_FinalBoss",
@@ -20576,102 +11987,6 @@
     "lat": -18616.083984375,
     "lng": -26558.501953125,
     "alt": 6096.26025390625
-  },
-  {
-    "name": "JailDoor2",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -23281.30078125,
-    "lng": -22833.56640625,
-    "alt": 7182.0
-  },
-  {
-    "name": "JailDoor3",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -23281.30078125,
-    "lng": -22833.56640625,
-    "alt": 7182.0
-  },
-  {
-    "name": "JailDoor4",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -21807.650390625,
-    "lng": -23520.74609375,
-    "alt": 7182.0
-  },
-  {
-    "name": "JailDoor_2",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -22604.314453125,
-    "lng": -23149.27734375,
-    "alt": 7182.0
-  },
-  {
-    "name": "JailWall1",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -23712.0078125,
-    "lng": -25723.349609375,
-    "alt": 7195.0
-  },
-  {
-    "name": "JailWall11",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24029.517578125,
-    "lng": -24724.58984375,
-    "alt": 7195.0
-  },
-  {
-    "name": "JailWall12_2",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24573.30078125,
-    "lng": -24471.01953125,
-    "alt": 7195.0
-  },
-  {
-    "name": "JailWall13",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -25117.087890625,
-    "lng": -24217.44921875,
-    "alt": 7195.0
-  },
-  {
-    "name": "JailWall2_3",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24504.421875,
-    "lng": -25353.841796875,
-    "alt": 7195.0
-  },
-  {
-    "name": "JailWall3",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -25053.34375,
-    "lng": -25097.87109375,
-    "alt": 7195.0
-  },
-  {
-    "name": "JailWall4",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24504.421875,
-    "lng": -25353.841796875,
-    "alt": 7595.0
-  },
-  {
-    "name": "JailWall6",
-    "type": "JailDoor_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -25053.345703125,
-    "lng": -25097.873046875,
-    "alt": 7595.0
   },
   {
     "name": "Jumppad2_2",
@@ -20690,40 +12005,13 @@
     "notsaved": true
   },
   {
-    "name": "BossPuzzleEnd1_KeyLockPlastic",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -20815.33203125,
-    "lng": -29347.435546875,
-    "alt": 6087.65087890625,
-    "variant": "blue"
-  },
-  {
-    "name": "BossPuzzleEnd2_KeyLockPlastic",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -22898.40234375,
-    "lng": -28363.3671875,
-    "alt": 6087.65087890625,
-    "variant": "blue"
-  },
-  {
-    "name": "BossPuzzleEnd3_KeyLockPlastic",
-    "type": "KeyLockPlastic_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -22095.98828125,
-    "lng": -26576.89453125,
-    "alt": 6087.65087890625,
-    "variant": "blue"
-  },
-  {
     "name": "Boss_Key1",
     "type": "KeyPlastic_C",
     "area": "DLC2_FinalBoss",
     "lat": -18492.396484375,
     "lng": -26333.28515625,
     "alt": 7249.45556640625,
-    "variant": "blue"
+    "variant": "orange"
   },
   {
     "name": "Boss_Key2",
@@ -20732,7 +12020,7 @@
     "lat": -22192.962890625,
     "lng": -25779.326171875,
     "alt": 6049.45556640625,
-    "variant": "blue"
+    "variant": "orange"
   },
   {
     "name": "Boss_Key3",
@@ -20741,7 +12029,7 @@
     "lat": -25142.982421875,
     "lng": -25289.48828125,
     "alt": 7255.0,
-    "variant": "blue"
+    "variant": "orange"
   },
   {
     "name": "BossPuzzle3_MatchBox",
@@ -20806,233 +12094,6 @@
     "variant": "stone"
   },
   {
-    "name": "Boss_RespawnButtonKey1",
-    "type": "PedestalButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -18607.513671875,
-    "lng": -26263.23828125,
-    "alt": 7165.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -26333.28515625,
-        "y": -18492.396484375,
-        "z": 7249.45556640625
-      }
-    ]
-  },
-  {
-    "name": "Boss_RespawnButtonKey2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -22269.38671875,
-    "lng": -25855.294921875,
-    "alt": 5981.24755859375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -25779.326171875,
-        "y": -22192.962890625,
-        "z": 6049.45556640625
-      }
-    ]
-  },
-  {
-    "name": "Boss_RespawnButtonKey3",
-    "type": "PedestalButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -25210.416015625,
-    "lng": -25434.1640625,
-    "alt": 7177.34326171875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -25289.48828125,
-        "y": -25142.982421875,
-        "z": 7255.0
-      }
-    ]
-  },
-  {
-    "name": "BossPuzzle2_ResetButton_MetalBall_Huge",
-    "type": "PedestalButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -23613.279296875,
-    "lng": -25668.71875,
-    "alt": 5595.01123046875
-  },
-  {
-    "name": "BossPuzzle3_JailDoor4_PedestalButton",
-    "type": "PedestalButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -25401.541015625,
-    "lng": -24825.890625,
-    "alt": 7344.83251953125
-  },
-  {
-    "name": "BossPuzzleEnd1_PedestalButton",
-    "type": "PedestalButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -20791.92578125,
-    "lng": -29420.947265625,
-    "alt": 5995.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -23642.3984375,
-        "y": -21571.9375,
-        "z": 5995.0
-      },
-      {
-        "x": -25358.8046875,
-        "y": -18835.640625,
-        "z": 5995.0
-      },
-      {
-        "x": -28787.82421875,
-        "y": -19954.9765625,
-        "z": 6395.0
-      },
-      {
-        "x": -24345.373046875,
-        "y": -21534.421875,
-        "z": 6030.90771484375
-      },
-      {
-        "x": -27882.685546875,
-        "y": -20051.919921875,
-        "z": 5995.0
-      },
-      {
-        "x": -30054.828125,
-        "y": -20071.126953125,
-        "z": 7161.45068359375
-      }
-    ]
-  },
-  {
-    "name": "BossPuzzleEnd2_PedestalButton",
-    "type": "PedestalButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -22971.900390625,
-    "lng": -28386.798828125,
-    "alt": 5995.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -23642.3984375,
-        "y": -21571.9375,
-        "z": 5995.0
-      },
-      {
-        "x": -25358.8046875,
-        "y": -18835.640625,
-        "z": 5995.0
-      },
-      {
-        "x": -28787.82421875,
-        "y": -19954.9765625,
-        "z": 6395.0
-      },
-      {
-        "x": -24345.373046875,
-        "y": -21534.421875,
-        "z": 6030.90771484375
-      },
-      {
-        "x": -27882.685546875,
-        "y": -20051.919921875,
-        "z": 5995.0
-      },
-      {
-        "x": -30054.828125,
-        "y": -20071.126953125,
-        "z": 7161.45068359375
-      }
-    ]
-  },
-  {
-    "name": "BossPuzzleEnd3_PedestalButton",
-    "type": "PedestalButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -22164.49609375,
-    "lng": -26541.45703125,
-    "alt": 5995.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -23642.3984375,
-        "y": -21571.9375,
-        "z": 5995.0
-      },
-      {
-        "x": -25358.8046875,
-        "y": -18835.640625,
-        "z": 5995.0
-      },
-      {
-        "x": -28787.82421875,
-        "y": -19954.9765625,
-        "z": 6395.0
-      },
-      {
-        "x": -24345.373046875,
-        "y": -21534.421875,
-        "z": 6030.90771484375
-      },
-      {
-        "x": -27882.685546875,
-        "y": -20051.919921875,
-        "z": 5995.0
-      },
-      {
-        "x": -30054.828125,
-        "y": -20071.126953125,
-        "z": 7161.45068359375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton12",
-    "type": "PedestalButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -22086.19921875,
-    "lng": -25048.640625,
-    "alt": 6122.88134765625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -25213.55078125,
-        "y": -21907.14453125,
-        "z": 5995.0
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton15",
-    "type": "PedestalButton_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -23231.537109375,
-    "lng": -23268.529296875,
-    "alt": 7188.26123046875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -23360.708984375,
-        "y": -23377.39453125,
-        "z": 7288.19580078125
-      }
-    ]
-  },
-  {
-    "name": "PipeCap12_2",
-    "type": "PipeCap_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -20071.126953125,
-    "lng": -30054.828125,
-    "alt": 7161.45068359375
-  },
-  {
     "name": "BossArea_BaronPipe1",
     "type": "PipesystemNew_C",
     "area": "DLC2_FinalBoss",
@@ -21064,38 +12125,6 @@
       "y": -9792.423828125,
       "z": 3239.46875
     }
-  },
-  {
-    "name": "NPC_InStocks",
-    "type": "RedGuy_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24756.146484375,
-    "lng": -25121.55078125,
-    "alt": 6085.2294921875
-  },
-  {
-    "name": "NPC_Zaheer",
-    "type": "RedGuy_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24656.43359375,
-    "lng": -23746.771484375,
-    "alt": 6169.27490234375
-  },
-  {
-    "name": "RedGuy2",
-    "type": "RedGuy_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24229.82421875,
-    "lng": -22912.580078125,
-    "alt": 6086.6845703125
-  },
-  {
-    "name": "RedGuy_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -24183.70703125,
-    "lng": -22845.5078125,
-    "alt": 6086.6845703125
   },
   {
     "name": "SecretFound22_2",
@@ -21144,170 +12173,6 @@
     "lat": -24775.64453125,
     "lng": -21660.93359375,
     "alt": 5933.626953125
-  },
-  {
-    "name": "BossArea_InEncounter_Volume1_5",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -20840.05078125,
-    "lng": -26664.017578125,
-    "alt": 6575.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -23642.3984375,
-        "y": -21571.9375,
-        "z": 5995.0
-      },
-      {
-        "x": -25358.8046875,
-        "y": -18835.640625,
-        "z": 5995.0
-      },
-      {
-        "x": -28787.82421875,
-        "y": -19954.9765625,
-        "z": 6395.0
-      },
-      {
-        "x": -24345.373046875,
-        "y": -21534.421875,
-        "z": 6030.90771484375
-      },
-      {
-        "x": -27882.685546875,
-        "y": -20051.919921875,
-        "z": 5995.0
-      },
-      {
-        "x": -30054.828125,
-        "y": -20071.126953125,
-        "z": 7161.45068359375
-      }
-    ]
-  },
-  {
-    "name": "BossArea_InEncounter_Volume2_6",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -21007.94140625,
-    "lng": -23893.509765625,
-    "alt": 6875.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -23642.3984375,
-        "y": -21571.9375,
-        "z": 5995.0
-      },
-      {
-        "x": -25358.8046875,
-        "y": -18835.640625,
-        "z": 5995.0
-      },
-      {
-        "x": -28787.82421875,
-        "y": -19954.9765625,
-        "z": 6395.0
-      },
-      {
-        "x": -24345.373046875,
-        "y": -21534.421875,
-        "z": 6030.90771484375
-      },
-      {
-        "x": -27882.685546875,
-        "y": -20051.919921875,
-        "z": 5995.0
-      },
-      {
-        "x": -30054.828125,
-        "y": -20071.126953125,
-        "z": 7161.45068359375
-      }
-    ]
-  },
-  {
-    "name": "Trigger_MakeSureBossExists1",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -19126.939453125,
-    "lng": -23003.298828125,
-    "alt": 6165.81982421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -23642.3984375,
-        "y": -21571.9375,
-        "z": 5995.0
-      },
-      {
-        "x": -25358.8046875,
-        "y": -18835.640625,
-        "z": 5995.0
-      },
-      {
-        "x": -28787.82421875,
-        "y": -19954.9765625,
-        "z": 6395.0
-      },
-      {
-        "x": -24345.373046875,
-        "y": -21534.421875,
-        "z": 6030.90771484375
-      },
-      {
-        "x": -27882.685546875,
-        "y": -20051.919921875,
-        "z": 5995.0
-      },
-      {
-        "x": -30054.828125,
-        "y": -20071.126953125,
-        "z": 7161.45068359375
-      }
-    ]
-  },
-  {
-    "name": "Trigger_MakeSureBossExists2",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_FinalBoss",
-    "lat": -21273.5390625,
-    "lng": -26471.126953125,
-    "alt": 7020.81982421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -23642.3984375,
-        "y": -21571.9375,
-        "z": 5995.0
-      },
-      {
-        "x": -25358.8046875,
-        "y": -18835.640625,
-        "z": 5995.0
-      },
-      {
-        "x": -28787.82421875,
-        "y": -19954.9765625,
-        "z": 6395.0
-      },
-      {
-        "x": -24345.373046875,
-        "y": -21534.421875,
-        "z": 6030.90771484375
-      },
-      {
-        "x": -27882.685546875,
-        "y": -20051.919921875,
-        "z": 5995.0
-      },
-      {
-        "x": -30054.828125,
-        "y": -20071.126953125,
-        "z": 7161.45068359375
-      }
-    ]
   },
   {
     "name": "BuyQuintupleJump",
@@ -21390,124 +12255,12 @@
     "variant": "yellow"
   },
   {
-    "name": "Door33_968",
-    "type": "Door3_C",
-    "area": "DLC2_Area0",
-    "lat": -287626.0,
-    "lng": -2003.5,
-    "alt": 10063.390625
-  },
-  {
-    "name": "Door34",
-    "type": "Door3_C",
-    "area": "DLC2_Area0",
-    "lat": -286704.15625,
-    "lng": 1001.808349609375,
-    "alt": 9816.3203125
-  },
-  {
-    "name": "Door36",
-    "type": "Door3_C",
-    "area": "DLC2_Area0",
-    "lat": -290626.0,
-    "lng": -538.0,
-    "alt": 10333.171875
-  },
-  {
-    "name": "Door37",
-    "type": "Door3_C",
-    "area": "DLC2_Area0",
-    "lat": -290629.0,
-    "lng": -1027.5,
-    "alt": 10333.171875
-  },
-  {
-    "name": "Door38",
-    "type": "Door3_C",
-    "area": "DLC2_Area0",
-    "lat": -289570.0,
-    "lng": -543.5,
-    "alt": 10333.171875
-  },
-  {
-    "name": "Door39",
-    "type": "Door3_C",
-    "area": "DLC2_Area0",
-    "lat": -289573.0,
-    "lng": -1033.0,
-    "alt": 10333.171875
-  },
-  {
-    "name": "Door40",
-    "type": "Door3_C",
-    "area": "DLC2_Area0",
-    "lat": -285345.0,
-    "lng": -1320.0,
-    "alt": 9807.4140625
-  },
-  {
-    "name": "Door66",
-    "type": "Door3_C",
-    "area": "DLC2_Area0",
-    "lat": -282728.0,
-    "lng": -557.0,
-    "alt": 9868.9609375
-  },
-  {
-    "name": "DoorAnna2_4",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Area0",
-    "lat": -289338.1875,
-    "lng": -2759.0,
-    "alt": 10529.0
-  },
-  {
-    "name": "DoorAnna_2",
-    "type": "DoorAnna_C",
-    "area": "DLC2_Area0",
-    "lat": -289909.75,
-    "lng": -2151.0,
-    "alt": 10529.0
-  },
-  {
     "name": "Juicer3",
     "type": "Juicer_C",
     "area": "DLC2_Area0",
     "lat": -286991.0,
     "lng": -4023.0,
     "alt": 10127.109375
-  },
-  {
-    "name": "PedestalButton2_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Area0",
-    "lat": -283208.03125,
-    "lng": -343.2530212402344,
-    "alt": 9809.943359375
-  },
-  {
-    "name": "PedestalButton3_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_Area0",
-    "lat": -286730.125,
-    "lng": 1466.3447265625,
-    "alt": 9799.03515625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 1408.9046630859375,
-        "y": -286630.25,
-        "z": 9887.1015625
-      }
-    ]
-  },
-  {
-    "name": "PipeCap10_2",
-    "type": "PipeCap_C",
-    "area": "DLC2_Area0",
-    "lat": -284028.03125,
-    "lng": -2240.900146484375,
-    "alt": 9974.640625
   },
   {
     "name": "PipesystemNew_AboveSewer",
@@ -21527,934 +12280,13 @@
     "notsaved": true
   },
   {
-    "name": "Plumbus2_9",
-    "type": "Plumbus_C",
-    "area": "DLC2_Area0",
-    "lat": -286714.84375,
-    "lng": 1553.7646484375,
-    "alt": 9817.3203125
-  },
-  {
-    "name": "Plumbus3_14",
-    "type": "Plumbus_C",
-    "area": "DLC2_Area0",
-    "lat": -285593.0,
-    "lng": 176.0,
-    "alt": 10151.0
-  },
-  {
-    "name": "Plumbus5_29",
-    "type": "Plumbus_C",
-    "area": "DLC2_Area0",
-    "lat": -287575.34375,
-    "lng": -2546.610107421875,
-    "alt": 10082.0
-  },
-  {
-    "name": "Plumbus6_34",
-    "type": "Plumbus_C",
-    "area": "DLC2_Area0",
-    "lat": -289776.40625,
-    "lng": -3123.60400390625,
-    "alt": 10557.0234375
-  },
-  {
-    "name": "Plumbus7_39",
-    "type": "Plumbus_C",
-    "area": "DLC2_Area0",
-    "lat": -290262.125,
-    "lng": -2530.65869140625,
-    "alt": 10557.224609375
-  },
-  {
-    "name": "Plumbus8_44",
-    "type": "Plumbus_C",
-    "area": "DLC2_Area0",
-    "lat": -284430.0,
-    "lng": -3319.0,
-    "alt": 9973.140625
-  },
-  {
-    "name": "Plumbus9_49",
-    "type": "Plumbus_C",
-    "area": "DLC2_Area0",
-    "lat": -282252.6875,
-    "lng": -582.0,
-    "alt": 9907.0
-  },
-  {
-    "name": "Plumbus_4",
-    "type": "Plumbus_C",
-    "area": "DLC2_Area0",
-    "lat": -284190.375,
-    "lng": 902.2235717773438,
-    "alt": 9808.3916015625
-  },
-  {
-    "name": "BlueKing",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283061.6875,
-    "lng": -594.5,
-    "alt": 9928.9921875,
-    "variant": "blue"
-  },
-  {
-    "name": "BluePrince",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282985.65625,
-    "lng": -574.5,
-    "alt": 9950.1328125,
-    "variant": "blue"
-  },
-  {
-    "name": "Historian1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -290347.1875,
-    "lng": -220.2820587158203,
-    "alt": 10391.0,
-    "variant": "red"
-  },
-  {
-    "name": "Kid_Blue",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282608.90625,
-    "lng": 442.0,
-    "alt": 9726.890625,
-    "variant": "blue"
-  },
-  {
-    "name": "Kid_Purple",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283805.6875,
-    "lng": -809.562744140625,
-    "alt": 9884.1533203125,
-    "variant": "purple"
-  },
-  {
-    "name": "Merchant_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283723.75,
-    "lng": 338.0438537597656,
-    "alt": 9788.515625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy11",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283315.875,
-    "lng": -762.0,
-    "alt": 9928.9921875,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy12",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282668.5625,
-    "lng": -75.5,
-    "alt": 9900.9990234375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy14",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283364.15625,
-    "lng": -197.5,
-    "alt": 9865.359375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy18",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283429.21875,
-    "lng": -965.5,
-    "alt": 9951.5,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy19",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282982.40625,
-    "lng": -277.5,
-    "alt": 9896.3984375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy2_5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -287705.5625,
-    "lng": -2412.982177734375,
-    "alt": 10227.8740234375,
-    "variant": "purple"
-  },
-  {
-    "name": "RedGuy3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282912.78125,
-    "lng": 10.5,
-    "alt": 9849.8203125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy4_4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282858.90625,
-    "lng": 2272.1220703125,
-    "alt": 9429.3291015625
-  },
-  {
-    "name": "RedGuy59_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285158.90625,
-    "lng": -38.6811637878418,
-    "alt": 9863.849609375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy60",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285254.96875,
-    "lng": 6.116137504577637,
-    "alt": 9880.4951171875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy61_6",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -284971.96875,
-    "lng": -101.57514953613281,
-    "alt": 9840.0380859375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy62",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285706.96875,
-    "lng": 518.1161499023438,
-    "alt": 9985.54296875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283145.875,
-    "lng": -718.5,
-    "alt": 9933.0703125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -287539.1875,
-    "lng": -2364.0537109375,
-    "alt": 10167.0,
-    "variant": "blue"
-  },
-  {
-    "name": "RedKing1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -289804.65625,
-    "lng": -965.7030029296875,
-    "alt": 10391.625,
-    "variant": "red"
-  },
-  {
-    "name": "RedKing2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283235.09375,
-    "lng": -424.7285461425781,
-    "alt": 9895.9921875,
-    "variant": "red"
-  },
-  {
-    "name": "RedQueen1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -289901.6875,
-    "lng": -570.2831420898438,
-    "alt": 10391.625,
-    "variant": "red"
-  },
-  {
-    "name": "RedQueen2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283366.59375,
-    "lng": -502.0,
-    "alt": 9892.03125,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator10_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -288329.21875,
-    "lng": -2123.1494140625,
-    "alt": 10640.28125,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator10_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283721.1875,
-    "lng": -1052.0,
-    "alt": 9929.8203125,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator1_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -289444.0,
-    "lng": -3191.0,
-    "alt": 10640.2109375,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator1_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -284592.4375,
-    "lng": -1527.5,
-    "alt": 9921.46875,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator2_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -289475.0,
-    "lng": -2823.0,
-    "alt": 10640.2109375,
-    "variant": "blue"
-  },
-  {
-    "name": "Spectator2_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -284725.78125,
-    "lng": -1504.5,
-    "alt": 9910.8203125,
-    "variant": "blue"
-  },
-  {
-    "name": "Spectator2_3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -289654.0,
-    "lng": -3052.0,
-    "alt": 10667.2109375,
-    "variant": "blue"
-  },
-  {
-    "name": "Spectator3_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -288958.875,
-    "lng": 182.5,
-    "alt": 10389.2109375,
-    "variant": "blue"
-  },
-  {
-    "name": "Spectator3_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -284580.84375,
-    "lng": -713.0,
-    "alt": 9830.8203125,
-    "variant": "blue"
-  },
-  {
-    "name": "Spectator4_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -288297.15625,
-    "lng": -2248.6494140625,
-    "alt": 10640.2109375,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator4_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -284911.78125,
-    "lng": -1489.5,
-    "alt": 9910.8203125,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator5_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -289759.875,
-    "lng": 182.5,
-    "alt": 10389.2109375,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator5_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -284305.0,
-    "lng": -312.5,
-    "alt": 9813.8203125,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator5_3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -289054.46875,
-    "lng": 294.5,
-    "alt": 10389.2109375,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator6_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -287761.875,
-    "lng": -2128.5,
-    "alt": 10168.0234375,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator6_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283089.59375,
-    "lng": 1161.0,
-    "alt": 9577.90625,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator7_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -287506.875,
-    "lng": -2217.5,
-    "alt": 10168.0234375,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator7_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283837.65625,
-    "lng": 857.0,
-    "alt": 9789.515625,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator8_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -288453.21875,
-    "lng": -64.5,
-    "alt": 10392.2109375,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator8_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282810.71875,
-    "lng": 639.5,
-    "alt": 9705.8203125,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator9_1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -289321.375,
-    "lng": 180.13087463378906,
-    "alt": 10389.28125,
-    "variant": "red"
-  },
-  {
-    "name": "Spectator9_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283165.90625,
-    "lng": 996.9146118164062,
-    "alt": 9595.0234375,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorBlocker1",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285550.46875,
-    "lng": -348.17938232421875,
-    "alt": 9888.875,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorBlocker2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285605.25,
-    "lng": -248.08143615722656,
-    "alt": 9886.375,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorBlocker3",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285556.9375,
-    "lng": -125.75531768798828,
-    "alt": 9883.7998046875,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorBlocker4",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285544.4375,
-    "lng": -24.67899513244629,
-    "alt": 9893.171875,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_10",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283042.9375,
-    "lng": 34.0,
-    "alt": 9837.2421875,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_12",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -284462.40625,
-    "lng": -203.47625732421875,
-    "alt": 9821.3828125,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_14",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -284437.375,
-    "lng": -1534.5,
-    "alt": 9910.8203125,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_15",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285074.03125,
-    "lng": -86.13468933105469,
-    "alt": 9848.93359375,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_16",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283878.625,
-    "lng": -1401.0,
-    "alt": 9912.8203125,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_17",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285146.8125,
-    "lng": -1969.0,
-    "alt": 9903.9912109375,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_18",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283706.09375,
-    "lng": -1245.0,
-    "alt": 9941.3046875,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_19",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -284571.84375,
-    "lng": -220.49853515625,
-    "alt": 9800.0439453125,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283973.8125,
-    "lng": -1524.0,
-    "alt": 9940.318359375,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_20",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282814.5,
-    "lng": 130.0,
-    "alt": 9847.1875,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_21",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283377.25,
-    "lng": 656.0,
-    "alt": 9711.40625,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_22",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283279.09375,
-    "lng": 799.0,
-    "alt": 9673.7734375,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_25",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283656.15625,
-    "lng": -744.5,
-    "alt": 9905.5234375,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_26",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282700.90625,
-    "lng": 473.0,
-    "alt": 9765.3125,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_27",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282479.375,
-    "lng": 97.00009155273438,
-    "alt": 9866.9189453125,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_28",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283033.90625,
-    "lng": 799.0,
-    "alt": 9667.7734375,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_30",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282637.90625,
-    "lng": 346.0,
-    "alt": 9779.3125,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_31",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -282913.625,
-    "lng": 799.0,
-    "alt": 9664.654296875,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_32",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285090.15625,
-    "lng": -1457.5020751953125,
-    "alt": 9889.9580078125,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_33",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283733.15625,
-    "lng": -856.0,
-    "alt": 9902.8203125,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_35",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283781.125,
-    "lng": -578.5,
-    "alt": 9872.8203125,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_39",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283512.75,
-    "lng": 511.5,
-    "alt": 9733.1640625,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_41",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -284807.8125,
-    "lng": -1476.42431640625,
-    "alt": 9879.91796875,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285336.53125,
-    "lng": 63.0,
-    "alt": 9879.369140625,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_7",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -285234.75,
-    "lng": -510.0,
-    "alt": 9893.9140625,
-    "variant": "red"
-  },
-  {
-    "name": "SpectatorStanding_8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283534.90625,
-    "lng": -149.45079040527344,
-    "alt": 9835.1796875,
-    "variant": "blue"
-  },
-  {
-    "name": "SpectatorStanding_9",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0",
-    "lat": -283636.1875,
-    "lng": -262.5,
-    "alt": 9859.7421875,
-    "variant": "red"
-  },
-  {
-    "name": "TalkingSpeaker2",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Area0",
-    "lat": -286302.375,
-    "lng": 278.02166748046875,
-    "alt": 10367.875
-  },
-  {
-    "name": "TalkingSpeaker3",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Area0",
-    "lat": -282936.25,
-    "lng": -603.7203369140625,
-    "alt": 10510.9443359375
-  },
-  {
-    "name": "TalkingSpeaker5",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Area0",
-    "lat": -290592.03125,
-    "lng": -1187.91162109375,
-    "alt": 10589.2783203125
-  },
-  {
-    "name": "TalkingSpeaker_2",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_Area0",
-    "lat": -287538.3125,
-    "lng": -2000.2119140625,
-    "alt": 11510.1943359375
-  },
-  {
-    "name": "TriggerVolume10",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -283935.84375,
-    "lng": -994.0,
-    "alt": 10006.046875
-  },
-  {
-    "name": "TriggerVolume11_InitialFog",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -290161.9375,
-    "lng": -2371.97314453125,
-    "alt": 10636.2509765625
-  },
-  {
-    "name": "TriggerVolume3",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -288600.84375,
-    "lng": -1880.0,
-    "alt": 10676.046875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -543.5,
-        "y": -289570.0,
-        "z": 10333.171875
-      },
-      {
-        "x": -1033.0,
-        "y": -289573.0,
-        "z": 10333.171875
-      }
-    ]
-  },
-  {
-    "name": "TriggerVolume4",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -287985.84375,
-    "lng": -930.0,
-    "alt": 10462.046875
-  },
-  {
-    "name": "TriggerVolume5",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -284737.09375,
-    "lng": -806.6566162109375,
-    "alt": 9922.046875
-  },
-  {
-    "name": "TriggerVolume7",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -283914.84375,
-    "lng": -1420.0,
-    "alt": 10006.046875
-  },
-  {
-    "name": "TriggerVolume9",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -283258.53125,
-    "lng": 264.0,
-    "alt": 9827.046875
-  },
-  {
-    "name": "TriggerVolume_2",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -289570.5625,
-    "lng": -2166.5,
-    "alt": 10686.046875
-  },
-  {
-    "name": "TriggerVolume_Fog1",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -286950.0,
-    "lng": -1294.0,
-    "alt": 11216.0
-  },
-  {
-    "name": "TriggerVolume_Fog2",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -286950.0,
-    "lng": -1294.0,
-    "alt": 11216.0
-  },
-  {
-    "name": "TriggerVolume_NoRocks1",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -287990.0,
-    "lng": -1294.0,
-    "alt": 10444.0
-  },
-  {
-    "name": "TriggerVolume_NoRocks2",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -286508.0,
-    "lng": 1108.0,
-    "alt": 10444.0
-  },
-  {
-    "name": "TriggerVolume_NoRocks3",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -283006.0,
-    "lng": 1498.0,
-    "alt": 10529.0
-  },
-  {
-    "name": "TriggerVolume_NoRocks4",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -285681.0,
-    "lng": -2757.0,
-    "alt": 10444.0
-  },
-  {
-    "name": "TriggerVolume_NoRocks5",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0",
-    "lat": -285681.0,
-    "lng": 171.0,
-    "alt": 10444.0
-  },
-  {
     "name": "ValveCarriable_288",
     "type": "ValveCarriable_C",
     "area": "DLC2_Area0",
     "lat": -290017.5,
     "lng": -2067.0,
     "alt": 10764.1484375,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "ValveCarriable_Orange",
@@ -22463,7 +12295,7 @@
     "lat": -286630.25,
     "lng": 1408.9046630859375,
     "alt": 9887.1015625,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "ValveCarriable_Purple",
@@ -22472,7 +12304,7 @@
     "lat": -284053.03125,
     "lng": 15.205077171325684,
     "alt": 9785.2578125,
-    "variant": "red"
+    "variant": "blue"
   },
   {
     "name": "ValveSlot2_2",
@@ -22481,15 +12313,7 @@
     "lat": -290014.9375,
     "lng": -2064.678955078125,
     "alt": 10688.0,
-    "variant": "green",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -2151.0,
-        "y": -289909.75,
-        "z": 10529.0
-      }
-    ]
+    "variant": "orange"
   },
   {
     "name": "ValveSlot_2",
@@ -22498,7 +12322,7 @@
     "lat": -284052.21875,
     "lng": 14.705077171325684,
     "alt": 9785.34375,
-    "variant": "purple"
+    "variant": "red"
   },
   {
     "name": "Bones_2",
@@ -22507,62 +12331,6 @@
     "lat": -1642.2034912109375,
     "lng": -16584.927734375,
     "alt": 3105.4658203125
-  },
-  {
-    "name": "BP_TriggerVolume_2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 10721.306640625,
-    "lng": 85.6121597290039,
-    "alt": 2897.72412109375
-  },
-  {
-    "name": "BP_TriggerVolume_PlayerInArenaArea",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 638.6362915039062,
-    "lng": -16884.978515625,
-    "alt": 4703.7626953125
-  },
-  {
-    "name": "SecretLavaArea_ArenaPuzzle_EmergencyExitTrigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 718.5736694335938,
-    "lng": -17389.279296875,
-    "alt": 3165.0244140625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -14423.1806640625,
-        "y": 807.2150268554688,
-        "z": 1420.0
-      }
-    ]
-  },
-  {
-    "name": "SecretLavaArea_SoftLockPrevention_Trigger",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 3354.944580078125,
-    "lng": -5521.21728515625,
-    "alt": 1398.68798828125
-  },
-  {
-    "name": "ButtonFloor2",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 2976.564697265625,
-    "lng": 2182.0537109375,
-    "alt": 702.18212890625
-  },
-  {
-    "name": "ButtonFloor_2",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 4755.34326171875,
-    "lng": 3959.14599609375,
-    "alt": 504.236572265625
   },
   {
     "name": "CarryStones_Heavy1",
@@ -23782,30 +13550,6 @@
     "coins": 1
   },
   {
-    "name": "SecretLavaArea_ArenaDoor",
-    "type": "DoorInverted_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 804.4298706054688,
-    "lng": -14442.9853515625,
-    "alt": 1420.0
-  },
-  {
-    "name": "SecretLavaArea_ArenaPuzzle_Door",
-    "type": "DoorInverted_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 807.2150268554688,
-    "lng": -14423.1806640625,
-    "alt": 1420.0
-  },
-  {
-    "name": "SecretLavaArea_ArenaPuzzle_DoorExit",
-    "type": "DoorInverted_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": -1160.14599609375,
-    "lng": -16923.580078125,
-    "alt": 3020.0
-  },
-  {
     "name": "ExplodingBattery_2",
     "type": "ExplodingBattery_C",
     "area": "DLC2_SecretLavaArea",
@@ -23817,13 +13561,13 @@
     "name": "Jumppad",
     "type": "Jumppad_C",
     "area": "DLC2_SecretLavaArea",
-    "lat": 7389.45263671875,
-    "lng": 1531.5936279296875,
-    "alt": 417.341064453125,
+    "lat": 7444.46044921875,
+    "lng": 1842.9071044921875,
+    "alt": 435.5234375,
     "target": {
-      "x": 2701.668622493744,
-      "y": 7076.49394261837,
-      "z": 533.2360745754241
+      "x": 2795.6824572086334,
+      "y": 7189.622655451298,
+      "z": 564.3886385995864
     },
     "linetype": "jumppad",
     "variant": "blue",
@@ -23837,29 +13581,13 @@
     "lng": -15567.2978515625,
     "alt": 1427.23388671875,
     "target": {
-      "x": -16642.64201436937,
-      "y": -789.3889227062464,
+      "x": -16642.641838163137,
+      "y": -789.3887465000153,
       "z": 3014.413952122942
     },
     "linetype": "jumppad",
     "variant": "blue",
     "notsaved": true
-  },
-  {
-    "name": "Lever17_2",
-    "type": "Lever_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 4586.12451171875,
-    "lng": -3891.43017578125,
-    "alt": 3286.9052734375
-  },
-  {
-    "name": "Match_Lever_5",
-    "type": "Match_Lever_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 8887.3740234375,
-    "lng": 1392.28076171875,
-    "alt": 980.12353515625
   },
   {
     "name": "MatchBox8_2",
@@ -24830,40 +14558,7 @@
     "lat": 8963.63671875,
     "lng": 819.0269165039062,
     "alt": 1160.0,
-    "variant": "stone",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 819.0269165039062,
-        "y": 8963.63671875,
-        "z": 1160.0
-      },
-      {
-        "x": 819.0269165039062,
-        "y": 8963.63671875,
-        "z": 1160.0
-      },
-      {
-        "x": 819.0269165039062,
-        "y": 8963.63671875,
-        "z": 1160.0
-      },
-      {
-        "x": 785.38330078125,
-        "y": 9089.2060546875,
-        "z": 1576.8359375
-      },
-      {
-        "x": 785.38330078125,
-        "y": 9089.2060546875,
-        "z": 1576.8359375
-      },
-      {
-        "x": 785.38330078125,
-        "y": 9089.2060546875,
-        "z": 1576.8359375
-      }
-    ]
+    "variant": "stone"
   },
   {
     "name": "MinecraftBrick96",
@@ -24963,86 +14658,6 @@
     "alt": 265.0
   },
   {
-    "name": "PedestalButton10",
-    "type": "PedestalButton_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 9426.6201171875,
-    "lng": 278.5731506347656,
-    "alt": 792.97119140625
-  },
-  {
-    "name": "PedestalButton9",
-    "type": "PedestalButton_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 9413.34375,
-    "lng": 247.9603729248047,
-    "alt": 758.150146484375
-  },
-  {
-    "name": "PedestalButton95_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 10348.8349609375,
-    "lng": -2491.52734375,
-    "alt": 458.500732421875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -2524.681884765625,
-        "y": 10266.990234375,
-        "z": 575.837158203125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": -631.0020141601562,
-    "lng": -15431.646484375,
-    "alt": 3015.2998046875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -15567.2978515625,
-        "y": 1964.4383544921875,
-        "z": 1427.23388671875
-      }
-    ]
-  },
-  {
-    "name": "Area1_SecretArea_TeleportPipeCap1",
-    "type": "PipeCap_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 3305.47607421875,
-    "lng": -280.1111755371094,
-    "alt": 797.051025390625
-  },
-  {
-    "name": "PipeCap11",
-    "type": "PipeCap_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 2748.60791015625,
-    "lng": -964.6672973632812,
-    "alt": 2625.2578125
-  },
-  {
-    "name": "PipeCap_FastTravelLavaToBeam1",
-    "type": "PipeCap_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 2676.927734375,
-    "lng": 9448.2138671875,
-    "alt": -7585.2919921875
-  },
-  {
-    "name": "PipeCap_FastTravelLavaToBeam2",
-    "type": "PipeCap_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": -22388.76171875,
-    "lng": 16856.8203125,
-    "alt": -2829.70068359375
-  },
-  {
     "name": "PipesystemNew39",
     "type": "PipesystemNew_C",
     "area": "DLC2_SecretLavaArea",
@@ -25053,9 +14668,9 @@
     "nearest_cap": "DLC2_SecretLavaArea:PipeCap11",
     "linetype": "pipe",
     "target": {
-      "x": -280.1111755371094,
-      "y": 3305.47607421875,
-      "z": 797.051025390625
+      "x": 318.6905212402344,
+      "y": 4593.765625,
+      "z": 1082.986083984375
     },
     "twoway": 2,
     "notsaved": true
@@ -25106,9 +14721,9 @@
     "name": "Secret_TeleportPipe1",
     "type": "PipesystemNew_C",
     "area": "DLC2_SecretLavaArea",
-    "lat": 3305.47607421875,
-    "lng": -280.1111755371094,
-    "alt": 797.051025390625,
+    "lat": 4593.765625,
+    "lng": 318.6905212402344,
+    "alt": 1082.986083984375,
     "other_pipe": "DLC2_SecretLavaArea:PipesystemNew39",
     "nearest_cap": "DLC2_SecretLavaArea:Area1_SecretArea_TeleportPipeCap1",
     "twoway": 1,
@@ -25192,16 +14807,16 @@
     "name": "PipesystemNewDLC_FastTravelLavaToBeam1",
     "type": "PipesystemNewDLC_C",
     "area": "DLC2_SecretLavaArea",
-    "lat": 2676.927734375,
-    "lng": 9448.2138671875,
-    "alt": -7585.2919921875,
+    "lat": 4345.25,
+    "lng": 8823.0712890625,
+    "alt": -7227.439453125,
     "other_pipe": "DLC2_SecretLavaArea:PipesystemNewDLC_FastTravelLavaToBeam2",
     "nearest_cap": "DLC2_SecretLavaArea:PipeCap_FastTravelLavaToBeam1",
     "linetype": "pipe",
     "target": {
-      "x": 16856.8203125,
-      "y": -22388.76171875,
-      "z": -2829.70068359375
+      "x": 17481.822265625,
+      "y": -24056.6484375,
+      "z": -2473.447998046875
     },
     "twoway": 2
   },
@@ -25209,35 +14824,18 @@
     "name": "PipesystemNewDLC_FastTravelLavaToBeam2",
     "type": "PipesystemNewDLC_C",
     "area": "DLC2_SecretLavaArea",
-    "lat": -22388.76171875,
-    "lng": 16856.8203125,
-    "alt": -2829.70068359375,
+    "lat": -24056.6484375,
+    "lng": 17481.822265625,
+    "alt": -2473.447998046875,
     "other_pipe": "DLC2_SecretLavaArea:PipesystemNewDLC_FastTravelLavaToBeam1",
     "nearest_cap": "DLC2_SecretLavaArea:PipeCap_FastTravelLavaToBeam2",
     "twoway": 1,
     "linetype": "pipe",
     "target": {
-      "x": 9448.2138671875,
-      "y": 2676.927734375,
-      "z": -7585.2919921875
+      "x": 8823.0712890625,
+      "y": 4345.25,
+      "z": -7227.439453125
     }
-  },
-  {
-    "name": "RedGuy2_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 4165.57958984375,
-    "lng": -55.31888961791992,
-    "alt": 1140.642333984375
-  },
-  {
-    "name": "RedGuy_PickaxeGuy",
-    "type": "RedGuy_C",
-    "area": "DLC2_SecretLavaArea",
-    "lat": 5297.00634765625,
-    "lng": -9300.9443359375,
-    "alt": 707.8359375,
-    "variant": "red"
   },
   {
     "name": "SecretFound2",
@@ -25334,7 +14932,7 @@
     "lat": 4967.49951171875,
     "lng": 8333.4755859375,
     "alt": -7631.91162109375,
-    "variant": "yellow"
+    "variant": "green"
   },
   {
     "name": "ValveSlot_2",
@@ -25343,36 +14941,7 @@
     "lat": 4922.91259765625,
     "lng": 8243.8955078125,
     "alt": -7577.89404296875,
-    "variant": "yellow",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 9448.2138671875,
-        "y": 2676.927734375,
-        "z": -7585.2919921875
-      },
-      {
-        "x": 16856.8203125,
-        "y": -22388.76171875,
-        "z": -2829.70068359375
-      }
-    ]
-  },
-  {
-    "name": "BallButton2_2",
-    "type": "BallButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -42479.15625,
-    "lng": -57406.09375,
-    "alt": 10351.3662109375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -55734.78515625,
-        "y": -42030.0546875,
-        "z": 9741.5400390625
-      }
-    ]
+    "variant": "green"
   },
   {
     "name": "BP_EngagementCup_Base12_37",
@@ -25453,291 +15022,6 @@
     "lat": -47840.1328125,
     "lng": -49320.54296875,
     "alt": 16208.3984375
-  },
-  {
-    "name": "BP_TriggerVolume10_15",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -43598.5390625,
-    "lng": -57599.23828125,
-    "alt": 8175.0498046875
-  },
-  {
-    "name": "BP_TriggerVolume11",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -43119.9140625,
-    "lng": -57225.31640625,
-    "alt": 8276.794921875
-  },
-  {
-    "name": "BP_TriggerVolume12_19",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -44460.9296875,
-    "lng": -55631.34375,
-    "alt": 10176.7783203125
-  },
-  {
-    "name": "BP_TriggerVolume13",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -44696.640625,
-    "lng": -55401.6015625,
-    "alt": 10176.7783203125
-  },
-  {
-    "name": "BP_TriggerVolume14_2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -40958.85546875,
-    "lng": -68200.5,
-    "alt": 5968.3818359375
-  },
-  {
-    "name": "BP_TriggerVolume2_2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -44970.34375,
-    "lng": -59300.390625,
-    "alt": 10334.0634765625
-  },
-  {
-    "name": "BP_TriggerVolume3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -45613.1015625,
-    "lng": -59430.00390625,
-    "alt": 10548.3056640625
-  },
-  {
-    "name": "BP_TriggerVolume48_2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -41589.0703125,
-    "lng": -52728.40625,
-    "alt": 12898.8369140625
-  },
-  {
-    "name": "BP_TriggerVolume49_5",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -40664.73828125,
-    "lng": -66473.046875,
-    "alt": 10710.0087890625
-  },
-  {
-    "name": "BP_TriggerVolume4_2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -39028.703125,
-    "lng": -68154.7109375,
-    "alt": 10043.2822265625
-  },
-  {
-    "name": "BP_TriggerVolume5",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -39064.19140625,
-    "lng": -68198.9140625,
-    "alt": 10217.2705078125
-  },
-  {
-    "name": "BP_TriggerVolume54_2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -40159.47265625,
-    "lng": -61669.94921875,
-    "alt": 10518.5205078125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -60952.66015625,
-        "y": -40498.19921875,
-        "z": 9721.6748046875
-      }
-    ]
-  },
-  {
-    "name": "BP_TriggerVolume6_6",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -41553.30078125,
-    "lng": -70603.953125,
-    "alt": 5766.8193359375
-  },
-  {
-    "name": "BP_TriggerVolume7",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -41782.953125,
-    "lng": -70730.6484375,
-    "alt": 5912.44091796875
-  },
-  {
-    "name": "BP_TriggerVolume8_11",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -49744.3046875,
-    "lng": -44518.734375,
-    "alt": 5847.6552734375
-  },
-  {
-    "name": "BP_TriggerVolume9",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -49176.8671875,
-    "lng": -44532.41015625,
-    "alt": 5951.37548828125
-  },
-  {
-    "name": "BP_TriggerVolume_2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -37868.7734375,
-    "lng": -56627.9609375,
-    "alt": 10068.025390625
-  },
-  {
-    "name": "ButtonFloor10_277",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -39302.203125,
-    "lng": -67615.296875,
-    "alt": 9767.1875
-  },
-  {
-    "name": "ButtonFloor2_2",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -40196.91796875,
-    "lng": -71553.59375,
-    "alt": 5540.91748046875
-  },
-  {
-    "name": "ButtonFloor3_271",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -40768.41796875,
-    "lng": -62582.6171875,
-    "alt": 9975.0
-  },
-  {
-    "name": "ButtonFloor4_271",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -40085.16015625,
-    "lng": -52634.6953125,
-    "alt": 9966.7490234375,
-    "variant": "yellow",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -57464.54296875,
-        "y": -42895.9296875,
-        "z": 9753.6689453125
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor5_5",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -36444.10546875,
-    "lng": -56009.88671875,
-    "alt": 5421.2802734375
-  },
-  {
-    "name": "ButtonFloor6_268",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -40272.61328125,
-    "lng": -63378.8984375,
-    "alt": 5808.53125,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -63536.07421875,
-        "y": -37633.59765625,
-        "z": 5389.29541015625
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor7",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -38640.95703125,
-    "lng": -52441.38671875,
-    "alt": 9966.7490234375,
-    "variant": "orange",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -52169.71875,
-        "y": -39590.11328125,
-        "z": 9963.939453125
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor8_271",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -47579.515625,
-    "lng": -46959.875,
-    "alt": 5590.12841796875,
-    "variant": "orange",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -48180.07421875,
-        "y": -47493.25,
-        "z": 5611.6337890625
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor9_274",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -45626.140625,
-    "lng": -58457.5546875,
-    "alt": 9884.7646484375,
-    "variant": "yellow",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -58980.828125,
-        "y": -44749.921875,
-        "z": 9745.3427734375
-      }
-    ]
-  },
-  {
-    "name": "ButtonFloor_276",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -37815.9921875,
-    "lng": -57130.1328125,
-    "alt": 9908.7919921875,
-    "variant": "orange",
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -56991.296875,
-        "y": -37803.3046875,
-        "z": 9913.333984375
-      }
-    ]
-  },
-  {
-    "name": "Floorbutton_GEN_VARIABLE_ButtonFloor_C_CAT_262",
-    "type": "ButtonFloor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -41882.84375,
-    "lng": -67533.890625,
-    "alt": 9868.1357421875
   },
   {
     "name": "CarrotPhysical2",
@@ -26626,94 +15910,6 @@
     "coins": 10
   },
   {
-    "name": "Door3_2",
-    "type": "Door3_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -41452.82421875,
-    "lng": -70460.40625,
-    "alt": 5516.87841796875
-  },
-  {
-    "name": "Door2_3",
-    "type": "Door_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -42895.9296875,
-    "lng": -57464.54296875,
-    "alt": 9753.6689453125
-  },
-  {
-    "name": "DoorInverted2_2",
-    "type": "Door_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -42030.0546875,
-    "lng": -55734.78515625,
-    "alt": 9741.5400390625
-  },
-  {
-    "name": "DoorInverted4",
-    "type": "Door_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -44749.921875,
-    "lng": -58980.828125,
-    "alt": 9745.3427734375
-  },
-  {
-    "name": "Door_2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -41221.6875,
-    "lng": -68778.609375,
-    "alt": 5436.00146484375
-  },
-  {
-    "name": "DoorInverted3_2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -47493.25,
-    "lng": -48180.07421875,
-    "alt": 5611.6337890625
-  },
-  {
-    "name": "DoorInverted5_6",
-    "type": "DoorInverted_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -39590.11328125,
-    "lng": -52169.71875,
-    "alt": 9963.939453125
-  },
-  {
-    "name": "DoorInverted_2",
-    "type": "DoorInverted_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -39130.96484375,
-    "lng": -53572.796875,
-    "alt": 5380.5947265625
-  },
-  {
-    "name": "DoorStone2_2",
-    "type": "DoorStone_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -37633.59765625,
-    "lng": -63536.07421875,
-    "alt": 5389.29541015625
-  },
-  {
-    "name": "DoorStone3_2",
-    "type": "DoorStone_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -46345.86328125,
-    "lng": -60287.10546875,
-    "alt": 9971.1142578125
-  },
-  {
-    "name": "DoorStone_2",
-    "type": "DoorStone_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -40498.19921875,
-    "lng": -60952.66015625,
-    "alt": 9721.6748046875
-  },
-  {
     "name": "ExplodingBattery9_5",
     "type": "ExplodingBattery_C",
     "area": "DLC2_PostRainbow",
@@ -26730,14 +15926,6 @@
     "alt": 9868.1357421875
   },
   {
-    "name": "JailDoor_4",
-    "type": "JailDoor_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -37803.3046875,
-    "lng": -56991.296875,
-    "alt": 9913.333984375
-  },
-  {
     "name": "Jumppad2_2",
     "type": "Jumppad_C",
     "area": "DLC2_PostRainbow",
@@ -26745,9 +15933,9 @@
     "lng": -46408.5859375,
     "alt": 6000.06689453125,
     "target": {
-      "x": -51490.62267237177,
-      "y": -40573.52105388278,
-      "z": 5108.342033183615
+      "x": -51490.62274339257,
+      "y": -40573.520998395135,
+      "z": 5108.342107152157
     },
     "linetype": "jumppad",
     "variant": "blue"
@@ -26760,9 +15948,9 @@
     "lng": -51595.203125,
     "alt": 5279.142578125,
     "target": {
-      "x": -50989.204087376595,
+      "x": -50989.20418214798,
       "y": -42940.384558200836,
-      "z": 5273.056977980615
+      "z": 5273.056883209229
     },
     "linetype": "jumppad",
     "variant": "blue"
@@ -26775,34 +15963,13 @@
     "lng": -47201.06640625,
     "alt": 11117.380859375,
     "target": {
-      "x": -47419.03840947151,
-      "y": -39061.84923744202,
+      "x": -47419.038460731506,
+      "y": -39061.84918618202,
       "z": 11348.466173575593
     },
     "linetype": "jumppad",
     "variant": "blue",
     "notsaved": true
-  },
-  {
-    "name": "Lever_2",
-    "type": "Lever_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -44074.22265625,
-    "lng": -46649.0625,
-    "alt": 6397.951171875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -46408.5859375,
-        "y": -44543.8828125,
-        "z": 6000.06689453125
-      },
-      {
-        "x": -51595.203125,
-        "y": -42061.2734375,
-        "z": 5279.142578125
-      }
-    ]
   },
   {
     "name": "MetalBall_2",
@@ -26848,210 +16015,6 @@
     "lng": -61236.3515625,
     "alt": 11472.673828125,
     "variant": "metal"
-  },
-  {
-    "name": "PedestalButton10_5",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -42835.390625,
-    "lng": -57263.2109375,
-    "alt": 9861.25390625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -57464.54296875,
-        "y": -42895.9296875,
-        "z": 9753.6689453125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton11_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -41246.359375,
-    "lng": -70098.5,
-    "alt": 5500.294921875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -70460.40625,
-        "y": -41452.82421875,
-        "z": 5516.87841796875
-      },
-      {
-        "x": -68778.609375,
-        "y": -41221.6875,
-        "z": 5436.00146484375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton12_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -37319.69140625,
-    "lng": -63387.203125,
-    "alt": 5864.42822265625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -63536.07421875,
-        "y": -37633.59765625,
-        "z": 5389.29541015625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton3_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -47761.3671875,
-    "lng": -47914.11328125,
-    "alt": 5729.9375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -48180.07421875,
-        "y": -47493.25,
-        "z": 5611.6337890625
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton4_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -46707.3671875,
-    "lng": -59585.3046875,
-    "alt": 10104.0390625
-  },
-  {
-    "name": "PedestalButton57_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -39495.73046875,
-    "lng": -60939.4453125,
-    "alt": 9891.2216796875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -60952.66015625,
-        "y": -40498.19921875,
-        "z": 9721.6748046875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton5_5",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -49776.9375,
-    "lng": -44494.00390625,
-    "alt": 5623.7255859375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -44579.65234375,
-        "y": -49780.01953125,
-        "z": 5663.71484375
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton6_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -37913.2890625,
-    "lng": -57395.26953125,
-    "alt": 9910.5166015625,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -57340.2734375,
-        "y": -37882.73828125,
-        "z": 9981.1953125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton8_5",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -39471.23046875,
-    "lng": -52351.76953125,
-    "alt": 10075.0927734375,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -52169.71875,
-        "y": -39590.11328125,
-        "z": 9963.939453125
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton9_5",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -43183.3828125,
-    "lng": -53317.6015625,
-    "alt": 9679.7529296875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -52913.67578125,
-        "y": -43117.48828125,
-        "z": 9684.9814453125
-      },
-      {
-        "x": -52984.97265625,
-        "y": -43401.4453125,
-        "z": 9688.857421875
-      },
-      {
-        "x": -52556.5234375,
-        "y": -43167.328125,
-        "z": 9686.97265625
-      },
-      {
-        "x": -52625.9140625,
-        "y": -43450.35546875,
-        "z": 9683.498046875
-      }
-    ]
-  },
-  {
-    "name": "PedestalButton_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -42953.171875,
-    "lng": -54759.24609375,
-    "alt": 9883.8935546875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -54644.8203125,
-        "y": -42874.6640625,
-        "z": 9932.017578125
-      }
-    ]
-  },
-  {
-    "name": "PipeCap2_2",
-    "type": "PipeCap_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -43132.2578125,
-    "lng": -70574.84375,
-    "alt": 5762.4091796875
-  },
-  {
-    "name": "PipeCap_2",
-    "type": "PipeCap_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -42775.58984375,
-    "lng": -52996.9140625,
-    "alt": 5645.86767578125
   },
   {
     "name": "PipesystemNew2",
@@ -27144,96 +16107,6 @@
       "z": 5190.4228515625
     },
     "notsaved": true
-  },
-  {
-    "name": "RedGuy10",
-    "type": "RedGuy_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -45084.890625,
-    "lng": -56251.30859375,
-    "alt": 9989.857421875,
-    "variant": "green"
-  },
-  {
-    "name": "RedGuy11",
-    "type": "RedGuy_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -45611.4765625,
-    "lng": -58478.203125,
-    "alt": 10159.1337890625,
-    "variant": "green"
-  },
-  {
-    "name": "RedGuy12",
-    "type": "RedGuy_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -46550.11328125,
-    "lng": -59433.17578125,
-    "alt": 10062.078125,
-    "variant": "green"
-  },
-  {
-    "name": "RedGuy14_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -41886.27734375,
-    "lng": -48835.5078125,
-    "alt": 12441.396484375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy15_5",
-    "type": "RedGuy_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -43414.49609375,
-    "lng": -75575.4140625,
-    "alt": 5422.96142578125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy3_12",
-    "type": "RedGuy_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -49701.3828125,
-    "lng": -44583.1328125,
-    "alt": 5709.72314453125,
-    "variant": "green"
-  },
-  {
-    "name": "RedGuy4_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -39291.93359375,
-    "lng": -67624.9609375,
-    "alt": 9967.4248046875,
-    "variant": "green"
-  },
-  {
-    "name": "RedGuy7",
-    "type": "RedGuy_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -41507.203125,
-    "lng": -70559.8515625,
-    "alt": 5600.58056640625,
-    "variant": "green"
-  },
-  {
-    "name": "RedGuy9",
-    "type": "RedGuy_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -43349.0703125,
-    "lng": -57904.02734375,
-    "alt": 7878.32568359375,
-    "variant": "green"
-  },
-  {
-    "name": "RedGuy_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -37619.6796875,
-    "lng": -57111.26171875,
-    "alt": 10003.67578125,
-    "variant": "green"
   },
   {
     "name": "RingColorer_5",
@@ -27398,92 +16271,12 @@
     "alt": 6085.283203125
   },
   {
-    "name": "TalkingSpeaker_2",
-    "type": "TalkingSpeaker_C",
-    "area": "DLC2_PostRainbow",
-    "lat": -44241.578125,
-    "lng": -56704.0625,
-    "alt": 9882.1220703125
-  },
-  {
     "name": "BP_PurchaseSpeedx2_2",
     "type": "BP_PurchaseSpeedx2_C",
     "area": "DLC2_Area0_Below",
     "lat": 23538.671875,
     "lng": 10969.87890625,
     "alt": 21214.2578125
-  },
-  {
-    "name": "BP_TriggerVolume2",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 21769.32421875,
-    "lng": 12008.6435546875,
-    "alt": 20990.0
-  },
-  {
-    "name": "BP_TriggerVolume3",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 26301.412109375,
-    "lng": 13090.736328125,
-    "alt": 19680.0
-  },
-  {
-    "name": "BP_TriggerVolume_7",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 20626.64453125,
-    "lng": 10832.0439453125,
-    "alt": 21110.0
-  },
-  {
-    "name": "BP_TriggerVolume_DisableCheckpoint",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 24750.765625,
-    "lng": 14656.95703125,
-    "alt": 18742.57421875
-  },
-  {
-    "name": "BP_TriggerVolume_MakeAboveCollapse",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 24845.75390625,
-    "lng": 14689.6328125,
-    "alt": 15460.376953125
-  },
-  {
-    "name": "BP_TriggerVolume_ShopFallA0",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22937.17578125,
-    "lng": 12518.478515625,
-    "alt": 20444.0
-  },
-  {
-    "name": "BP_TriggerVolume_ShopFallA0_Backup",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23031.76171875,
-    "lng": 11961.2392578125,
-    "alt": 21459.95703125
-  },
-  {
-    "name": "TriggerSewerChamber",
-    "type": "BP_TriggerVolume_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23630.703125,
-    "lng": 15265.16796875,
-    "alt": 19760.0,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": 12518.478515625,
-        "y": 22937.17578125,
-        "z": 20444.0
-      }
-    ]
   },
   {
     "name": "Coin703_2",
@@ -27531,14 +16324,6 @@
     "coins": 1
   },
   {
-    "name": "A0_EscapeDoor",
-    "type": "Door_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23295.990234375,
-    "lng": 16726.919921875,
-    "alt": 19475.0
-  },
-  {
     "name": "PipesystemNew_IntoSewer",
     "type": "PipesystemNew_C",
     "area": "DLC2_Area0_Below",
@@ -27564,780 +16349,30 @@
     "notsaved": true
   },
   {
-    "name": "RedGuy10",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23470.013671875,
-    "lng": 16145.6455078125,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy13",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23176.7109375,
-    "lng": 15712.015625,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy15",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23198.7421875,
-    "lng": 15945.970703125,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy16",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23186.068359375,
-    "lng": 15554.2470703125,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy17",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23763.154296875,
-    "lng": 16138.083984375,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23841.056640625,
-    "lng": 16300.642578125,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy20_20",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23090.115234375,
-    "lng": 13549.3671875,
-    "alt": 20452.796875,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy21_23",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22266.990234375,
-    "lng": 13916.4189453125,
-    "alt": 20113.453125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy22_26",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22397.22265625,
-    "lng": 12869.865234375,
-    "alt": 20420.296875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy23_29",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 20270.99609375,
-    "lng": 10610.6923828125,
-    "alt": 20975.515625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy24_32",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 21854.716796875,
-    "lng": 12403.2734375,
-    "alt": 20669.359375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy25_35",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 21357.12109375,
-    "lng": 11670.6103515625,
-    "alt": 20883.65625,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy26",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23398.177734375,
-    "lng": 15653.20703125,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy27",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23207.236328125,
-    "lng": 16169.4228515625,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy28",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23419.41015625,
-    "lng": 15886.544921875,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy29",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23631.3984375,
-    "lng": 16282.607421875,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy30",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23033.458984375,
-    "lng": 13344.4072265625,
-    "alt": 20452.796875,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy31",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23313.21484375,
-    "lng": 15455.3349609375,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy32",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 21840.06640625,
-    "lng": 16661.203125,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy33",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22330.11328125,
-    "lng": 16123.1181640625,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy34",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22544.4140625,
-    "lng": 16325.25,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy35",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22379.501953125,
-    "lng": 16421.6328125,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy36",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22276.68359375,
-    "lng": 16759.841796875,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy37",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22131.19140625,
-    "lng": 16556.080078125,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy38",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22470.322265625,
-    "lng": 16236.025390625,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy39",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22166.6171875,
-    "lng": 16295.09375,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy40",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 21986.96484375,
-    "lng": 16715.16796875,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy41",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22035.03125,
-    "lng": 16467.6796875,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy42",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22352.84765625,
-    "lng": 16555.7421875,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy43",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22505.541015625,
-    "lng": 13095.97265625,
-    "alt": 20379.359375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy44",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23315.4375,
-    "lng": 14495.7451171875,
-    "alt": 19644.5625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy45",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23217.810546875,
-    "lng": 14639.3173828125,
-    "alt": 19685.1796875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy46",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23013.552734375,
-    "lng": 14869.76953125,
-    "alt": 19685.75,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy47",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23099.6796875,
-    "lng": 14623.119140625,
-    "alt": 19689.7734375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy48",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22714.52734375,
-    "lng": 16411.765625,
-    "alt": 19554.5625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy49",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22609.6640625,
-    "lng": 16548.453125,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy50",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22405.384765625,
-    "lng": 16793.076171875,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy51",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22498.59765625,
-    "lng": 16539.33203125,
-    "alt": 19556.34375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy52",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22468.15625,
-    "lng": 16689.97265625,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy53",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22287.953125,
-    "lng": 16870.21484375,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy54",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22432.8828125,
-    "lng": 17015.185546875,
-    "alt": 19556.34375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy55",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22873.884765625,
-    "lng": 13185.01953125,
-    "alt": 20442.1796875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy56",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 22690.810546875,
-    "lng": 13000.53125,
-    "alt": 20395.484375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy57_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23681.94140625,
-    "lng": 11052.1201171875,
-    "alt": 21246.3515625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy58",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 23681.94140625,
-    "lng": 11052.1201171875,
-    "alt": 23050.3515625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy5_5",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 19266.01953125,
-    "lng": 11648.9306640625,
-    "alt": 21036.890625,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy6_8",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 19438.880859375,
-    "lng": 10606.3896484375,
-    "alt": 21017.046875,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy7_11",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 19227.068359375,
-    "lng": 10987.841796875,
-    "alt": 20952.412109375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy9",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 19722.06640625,
-    "lng": 11779.76953125,
-    "alt": 20993.71875,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 19622.974609375,
-    "lng": 10634.3974609375,
-    "alt": 21017.4609375,
-    "variant": "red"
-  },
-  {
-    "name": "SewerGirl",
-    "type": "RedGuy_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 24186.56640625,
-    "lng": 15696.6796875,
-    "alt": 19556.3359375,
-    "variant": "blue"
-  },
-  {
-    "name": "TriggerVolume6_2",
-    "type": "TriggerVolume_C",
-    "area": "DLC2_Area0_Below",
-    "lat": 24879.939453125,
-    "lng": 14877.5673828125,
-    "alt": 4642.16015625
-  },
-  {
     "name": "MinecraftBrick_GEN_VARIABLE_ValveCarriable_C_CAT_0",
     "type": "ValveCarriable_C",
     "area": "DLC2_Area0_Below",
     "lat": 25024.05078125,
     "lng": 15319.908203125,
     "alt": 19551.0,
-    "variant": "purple"
-  },
-  {
-    "name": "Door13",
-    "type": "Door3_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -23645.171875,
-    "lng": -64135.640625,
-    "alt": 7827.505859375
-  },
-  {
-    "name": "Door14",
-    "type": "Door3_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -20952.28125,
-    "lng": -63970.953125,
-    "alt": 7856.109375
-  },
-  {
-    "name": "Door45",
-    "type": "Door3_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22173.1328125,
-    "lng": -62646.4375,
-    "alt": 7733.4658203125
-  },
-  {
-    "name": "Door46",
-    "type": "Door3_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22417.6796875,
-    "lng": -57591.296875,
-    "alt": 7752.8232421875
-  },
-  {
-    "name": "PedestalButton22_2",
-    "type": "PedestalButton_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22048.5234375,
-    "lng": -62782.55078125,
-    "alt": 7850.966796875,
-    "linetype": "trigger",
-    "targets": [
-      {
-        "x": -62646.4375,
-        "y": -22173.1328125,
-        "z": 7733.4658203125
-      }
-    ]
-  },
-  {
-    "name": "RedGuy100_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -21748.6640625,
-    "lng": -56632.2578125,
-    "alt": 7827.9619140625,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy101",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -21735.64453125,
-    "lng": -56859.13671875,
-    "alt": 7853.5419921875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy102_6",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -21558.6171875,
-    "lng": -56688.3046875,
-    "alt": 7889.89599609375,
-    "variant": "orange"
-  },
-  {
-    "name": "RedGuy11",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22231.90625,
-    "lng": -57949.984375,
-    "alt": 7808.228515625,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy12",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -23111.7890625,
-    "lng": -61189.515625,
-    "alt": 8145.7763671875
-  },
-  {
-    "name": "RedGuy13",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -24549.3125,
-    "lng": -64545.890625,
-    "alt": 7937.58984375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy14",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -24550.0625,
-    "lng": -64288.25,
-    "alt": 7937.58984375,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy15",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -24402.796875,
-    "lng": -64544.53125,
-    "alt": 7937.58984375,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy16",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -24466.09375,
-    "lng": -62966.578125,
-    "alt": 8132.54248046875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy17",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -24529.890625,
-    "lng": -62815.734375,
-    "alt": 8132.54248046875
-  },
-  {
-    "name": "RedGuy18",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -24216.015625,
-    "lng": -62711.234375,
-    "alt": 8132.54248046875,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy19",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -23220.234375,
-    "lng": -64948.609375,
-    "alt": 7976.76806640625
-  },
-  {
-    "name": "RedGuy2",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22428.40234375,
-    "lng": -63335.9296875,
-    "alt": 7805.5244140625,
-    "variant": "orange"
-  },
-  {
-    "name": "RedGuy20",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22145.609375,
-    "lng": -58813.625,
-    "alt": 7926.73388671875,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy21",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22666.78125,
-    "lng": -62775.546875,
-    "alt": 7824.39453125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy3",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22484.76171875,
-    "lng": -63182.4609375,
-    "alt": 7810.1298828125,
-    "variant": "purple"
-  },
-  {
-    "name": "RedGuy4",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22219.390625,
-    "lng": -62843.71875,
-    "alt": 7822.69921875,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy5",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -23039.3984375,
-    "lng": -61905.625,
-    "alt": 8183.98876953125,
-    "variant": "green"
-  },
-  {
-    "name": "RedGuy6",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -23038.6875,
-    "lng": -61112.109375,
-    "alt": 8112.626953125
-  },
-  {
-    "name": "RedGuy7",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22156.375,
-    "lng": -61201.234375,
-    "alt": 8169.98828125
-  },
-  {
-    "name": "RedGuy8",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22002.578125,
-    "lng": -61136.453125,
-    "alt": 8170.7626953125,
-    "variant": "red"
-  },
-  {
-    "name": "RedGuy86",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -24366.8515625,
-    "lng": -62659.421875,
-    "alt": 8120.357421875,
-    "variant": "purple"
-  },
-  {
-    "name": "RedGuy87",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -23124.84375,
-    "lng": -61070.6484375,
-    "alt": 8133.8310546875
-  },
-  {
-    "name": "RedGuy88",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -22487.75,
-    "lng": -60974.80859375,
-    "alt": 8113.4599609375
-  },
-  {
-    "name": "RedGuy9",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -21910.484375,
-    "lng": -59893.671875,
-    "alt": 7914.57421875
-  },
-  {
-    "name": "RedGuy98",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -21328.6328125,
-    "lng": -62722.6640625,
-    "alt": 7849.7529296875,
-    "variant": "blue"
-  },
-  {
-    "name": "RedGuy_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_RainbowTown",
-    "lat": -21951.8828125,
-    "lng": -62350.59375,
-    "alt": 7823.060546875,
     "variant": "red"
   },
   {
     "name": "PipesystemNewDLC4",
     "type": "PipesystemNewDLC_C",
     "area": "DLC2_Menu_Splash",
-    "lat": 2373.376953125,
-    "lng": 3473.5615234375,
-    "alt": 1345.9921875,
+    "lat": -16626.623046875,
+    "lng": -1226.4384765625,
+    "alt": 3545.9921875,
     "notsaved": true
   },
   {
     "name": "SecretFound_2",
     "type": "SecretFound_C",
     "area": "DLC2_Menu_Splash",
-    "lat": -2673.81640625,
-    "lng": 4768.447265625,
-    "alt": 1513.098876953125
+    "lat": -21673.81640625,
+    "lng": 68.447265625,
+    "alt": 3713.098876953125
   },
   {
     "name": "SecretFound_2",
@@ -28365,13 +16400,598 @@
     "variant": "blue"
   },
   {
-    "name": "RedGuy_2",
-    "type": "RedGuy_C",
-    "area": "DLC2_Menu",
-    "lat": -17804.318359375,
-    "lng": -1026.892822265625,
-    "alt": 3441.56689453125,
-    "variant": "blue"
+    "name": "Coin708_2",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8515625,
+    "lng": 16312.1904296875,
+    "alt": 7789.0625,
+    "coins": 1
+  },
+  {
+    "name": "Coin726",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8505859375,
+    "lng": 16303.5908203125,
+    "alt": 7690.7890625,
+    "coins": 1
+  },
+  {
+    "name": "Coin727",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8486328125,
+    "lng": 16295.833984375,
+    "alt": 7602.1357421875,
+    "coins": 1
+  },
+  {
+    "name": "Coin728",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8486328125,
+    "lng": 16288.2265625,
+    "alt": 7515.234375,
+    "coins": 1
+  },
+  {
+    "name": "Coin729",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.84765625,
+    "lng": 16281.564453125,
+    "alt": 7439.076171875,
+    "coins": 1
+  },
+  {
+    "name": "Coin730",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8447265625,
+    "lng": 16275.1796875,
+    "alt": 7366.0927734375,
+    "coins": 1
+  },
+  {
+    "name": "Coin731",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8515625,
+    "lng": 16268.8701171875,
+    "alt": 7293.97412109375,
+    "coins": 1
+  },
+  {
+    "name": "Coin732",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8515625,
+    "lng": 16262.119140625,
+    "alt": 7216.81689453125,
+    "coins": 1
+  },
+  {
+    "name": "Coin733",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8544921875,
+    "lng": 16255.6064453125,
+    "alt": 7142.3759765625,
+    "coins": 1
+  },
+  {
+    "name": "Coin734",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.85546875,
+    "lng": 16248.8984375,
+    "alt": 7065.7802734375,
+    "coins": 1
+  },
+  {
+    "name": "Coin735",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8544921875,
+    "lng": 16242.2353515625,
+    "alt": 6989.62158203125,
+    "coins": 1
+  },
+  {
+    "name": "Coin736",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8544921875,
+    "lng": 16235.84765625,
+    "alt": 6916.63818359375,
+    "coins": 1
+  },
+  {
+    "name": "Coin737",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.85546875,
+    "lng": 16229.544921875,
+    "alt": 6844.51953125,
+    "coins": 1
+  },
+  {
+    "name": "Coin738",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.85546875,
+    "lng": 16222.7939453125,
+    "alt": 6767.36181640625,
+    "coins": 1
+  },
+  {
+    "name": "Coin739",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8544921875,
+    "lng": 16216.2841796875,
+    "alt": 6692.92041015625,
+    "coins": 1
+  },
+  {
+    "name": "Coin740",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.853515625,
+    "lng": 16209.767578125,
+    "alt": 6618.4482421875,
+    "coins": 1
+  },
+  {
+    "name": "Coin741",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8583984375,
+    "lng": 16202.9033203125,
+    "alt": 6540.01171875,
+    "coins": 1
+  },
+  {
+    "name": "Coin742",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.861328125,
+    "lng": 16196.28515625,
+    "alt": 6464.36181640625,
+    "coins": 1
+  },
+  {
+    "name": "Coin743",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -11656.8828125,
+    "lng": 16189.59375,
+    "alt": 6387.95458984375,
+    "coins": 1
+  },
+  {
+    "name": "Coin744_2",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -9158.556640625,
+    "lng": 41615.375,
+    "alt": 1287.02880859375,
+    "coins": 1
+  },
+  {
+    "name": "Coin745",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -9099.845703125,
+    "lng": 41623.05078125,
+    "alt": 1287.02880859375,
+    "coins": 1
+  },
+  {
+    "name": "Coin746_2",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32530.43359375,
+    "lng": -31006.6015625,
+    "alt": 22171.70703125,
+    "coins": 1
+  },
+  {
+    "name": "Coin747",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32550.115234375,
+    "lng": -31114.11328125,
+    "alt": 22168.80859375,
+    "coins": 1
+  },
+  {
+    "name": "Coin748",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32632.44140625,
+    "lng": -31169.671875,
+    "alt": 22145.1796875,
+    "coins": 1
+  },
+  {
+    "name": "Coin749",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32737.951171875,
+    "lng": -31158.314453125,
+    "alt": 22112.484375,
+    "coins": 1
+  },
+  {
+    "name": "Coin750",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32796.66015625,
+    "lng": -31065.650390625,
+    "alt": 22091.771484375,
+    "coins": 1
+  },
+  {
+    "name": "Coin751_19",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32479.798828125,
+    "lng": -31011.48046875,
+    "alt": 22006.48828125,
+    "coins": 1
+  },
+  {
+    "name": "Coin752",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32779.05859375,
+    "lng": -30969.04296875,
+    "alt": 22094.373046875,
+    "coins": 1
+  },
+  {
+    "name": "Coin753",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32687.095703125,
+    "lng": -30901.294921875,
+    "alt": 22120.61328125,
+    "coins": 1
+  },
+  {
+    "name": "Coin754",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32596.26171875,
+    "lng": -30921.06640625,
+    "alt": 22149.033203125,
+    "coins": 1
+  },
+  {
+    "name": "Coin755",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32499.48046875,
+    "lng": -31118.9921875,
+    "alt": 22003.58984375,
+    "coins": 1
+  },
+  {
+    "name": "Coin756",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32581.806640625,
+    "lng": -31174.55078125,
+    "alt": 21979.9609375,
+    "coins": 1
+  },
+  {
+    "name": "Coin757",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32687.31640625,
+    "lng": -31163.193359375,
+    "alt": 21947.265625,
+    "coins": 1
+  },
+  {
+    "name": "Coin758",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32746.025390625,
+    "lng": -31070.529296875,
+    "alt": 21926.552734375,
+    "coins": 1
+  },
+  {
+    "name": "Coin759",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32728.423828125,
+    "lng": -30973.921875,
+    "alt": 21929.154296875,
+    "coins": 1
+  },
+  {
+    "name": "Coin760",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32636.4609375,
+    "lng": -30906.173828125,
+    "alt": 21955.39453125,
+    "coins": 1
+  },
+  {
+    "name": "Coin761",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32545.626953125,
+    "lng": -30925.9453125,
+    "alt": 21983.814453125,
+    "coins": 1
+  },
+  {
+    "name": "Coin762",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32553.630859375,
+    "lng": -31004.376953125,
+    "alt": 22247.310546875,
+    "coins": 1
+  },
+  {
+    "name": "Coin763",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32573.3125,
+    "lng": -31111.888671875,
+    "alt": 22244.412109375,
+    "coins": 1
+  },
+  {
+    "name": "Coin764",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32655.638671875,
+    "lng": -31167.447265625,
+    "alt": 22220.783203125,
+    "coins": 1
+  },
+  {
+    "name": "Coin765",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32761.146484375,
+    "lng": -31156.08984375,
+    "alt": 22188.087890625,
+    "coins": 1
+  },
+  {
+    "name": "Coin766",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32819.8515625,
+    "lng": -31063.42578125,
+    "alt": 22167.375,
+    "coins": 1
+  },
+  {
+    "name": "Coin767",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32802.25,
+    "lng": -30966.818359375,
+    "alt": 22169.9765625,
+    "coins": 1
+  },
+  {
+    "name": "Coin768",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32710.29296875,
+    "lng": -30899.0703125,
+    "alt": 22196.216796875,
+    "coins": 1
+  },
+  {
+    "name": "Coin769",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32575.29296875,
+    "lng": -31002.345703125,
+    "alt": 22317.966796875,
+    "coins": 1
+  },
+  {
+    "name": "Coin770",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32594.974609375,
+    "lng": -31109.857421875,
+    "alt": 22315.068359375,
+    "coins": 1
+  },
+  {
+    "name": "Coin771",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32677.30078125,
+    "lng": -31165.416015625,
+    "alt": 22291.439453125,
+    "coins": 1
+  },
+  {
+    "name": "Coin772",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32782.8203125,
+    "lng": -31154.05859375,
+    "alt": 22258.744140625,
+    "coins": 1
+  },
+  {
+    "name": "Coin773",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32841.5234375,
+    "lng": -31061.39453125,
+    "alt": 22238.03125,
+    "coins": 1
+  },
+  {
+    "name": "Coin774",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32823.921875,
+    "lng": -30964.787109375,
+    "alt": 22240.6328125,
+    "coins": 1
+  },
+  {
+    "name": "Coin775",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32731.955078125,
+    "lng": -30897.0390625,
+    "alt": 22266.873046875,
+    "coins": 1
+  },
+  {
+    "name": "Coin776_38",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -21251.9921875,
+    "lng": -30643.529296875,
+    "alt": 24206.130859375,
+    "coins": 1
+  },
+  {
+    "name": "Coin777",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -21392.8125,
+    "lng": -30636.3359375,
+    "alt": 24335.982421875,
+    "coins": 1
+  },
+  {
+    "name": "Coin778",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -21557.326171875,
+    "lng": -30631.576171875,
+    "alt": 24484.310546875,
+    "coins": 1
+  },
+  {
+    "name": "Coin779",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -21721.41015625,
+    "lng": -30621.66796875,
+    "alt": 24588.7734375,
+    "coins": 1
+  },
+  {
+    "name": "Coin780",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -21898.390625,
+    "lng": -30612.265625,
+    "alt": 24642.197265625,
+    "coins": 1
+  },
+  {
+    "name": "Coin781",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -22221.109375,
+    "lng": -30599.59375,
+    "alt": 24637.90234375,
+    "coins": 1
+  },
+  {
+    "name": "Coin782",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -22386.470703125,
+    "lng": -30589.3984375,
+    "alt": 24560.998046875,
+    "coins": 1
+  },
+  {
+    "name": "Coin783",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -22542.189453125,
+    "lng": -30583.890625,
+    "alt": 24474.294921875,
+    "coins": 1
+  },
+  {
+    "name": "Coin784",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -22663.34765625,
+    "lng": -30574.66015625,
+    "alt": 24372.65625,
+    "coins": 1
+  },
+  {
+    "name": "Coin785",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -22789.658203125,
+    "lng": -30570.9921875,
+    "alt": 24240.134765625,
+    "coins": 1
+  },
+  {
+    "name": "Coin786_2",
+    "type": "Coin_C",
+    "area": "DLC2_LateChanges",
+    "lat": -24412.638671875,
+    "lng": 15181.58203125,
+    "alt": -201.4576873779297,
+    "coins": 1
+  },
+  {
+    "name": "CoinBig22",
+    "type": "CoinBig_C",
+    "area": "DLC2_LateChanges",
+    "lat": -27028.07421875,
+    "lng": -30707.572265625,
+    "alt": 23450.0,
+    "coins": 10
+  },
+  {
+    "name": "CoinBig23_2",
+    "type": "CoinBig_C",
+    "area": "DLC2_LateChanges",
+    "lat": -32581.599609375,
+    "lng": -31042.27734375,
+    "alt": 21872.845703125,
+    "coins": 10
+  },
+  {
+    "name": "CoinBig24",
+    "type": "CoinBig_C",
+    "area": "DLC2_LateChanges",
+    "lat": -20364.20703125,
+    "lng": -30320.052734375,
+    "alt": 21907.26953125,
+    "coins": 10
+  },
+  {
+    "name": "CoinBig25_6",
+    "type": "CoinBig_C",
+    "area": "DLC2_LateChanges",
+    "lat": -22057.443359375,
+    "lng": -30601.998046875,
+    "alt": 24617.12109375,
+    "coins": 10
   },
   {
     "name": "CoinStack2",

--- a/public/data/markers.siu.json
+++ b/public/data/markers.siu.json
@@ -16358,23 +16358,6 @@
     "variant": "red"
   },
   {
-    "name": "PipesystemNewDLC4",
-    "type": "PipesystemNewDLC_C",
-    "area": "DLC2_Menu_Splash",
-    "lat": -16626.623046875,
-    "lng": -1226.4384765625,
-    "alt": 3545.9921875,
-    "notsaved": true
-  },
-  {
-    "name": "SecretFound_2",
-    "type": "SecretFound_C",
-    "area": "DLC2_Menu_Splash",
-    "lat": -21673.81640625,
-    "lng": 68.447265625,
-    "alt": 3713.098876953125
-  },
-  {
     "name": "SecretFound_2",
     "type": "SecretFound_C",
     "area": "DLC2_Splash",

--- a/public/data/markers.sw.json
+++ b/public/data/markers.sw.json
@@ -14278,7 +14278,7 @@
     "lat": 2910.5810546875,
     "lng": 3667.495361328125,
     "alt": -112.62963104248047,
-    "area_tag": "OutskirtsStartTown",
+    "area_tag": "None",
     "comment": "Obvious Area"
   },
   {

--- a/scripts/supraland_parser.py
+++ b/scripts/supraland_parser.py
@@ -979,7 +979,9 @@ def in_earlyaccess(otype, p, pos):  # noqa: C901 - disable complexity warning
 
 
 def optEnum(s):
-    return int(s[len(s.rstrip('0123456789')) :] or 0) if type(s) is str and '::' in s and s[-1].isdigit() else s
+    if match := re.search('::.*([0-9]+)$', str(s)):
+        return int(match.group(1))
+    return s
 
 
 def optArea(a, k, v):

--- a/scripts/supraland_parser.py
+++ b/scripts/supraland_parser.py
@@ -979,7 +979,7 @@ def in_earlyaccess(otype, p, pos):  # noqa: C901 - disable complexity warning
 
 
 def optEnum(s):
-    return int(s[len(s.rstrip('0123456789')) :] or 0) if type(s) is str and '::' in s else s
+    return int(s[len(s.rstrip('0123456789')) :] or 0) if type(s) is str and '::' in s and s[-1].isdigit() else s
 
 
 def optArea(a, k, v):
@@ -1205,7 +1205,7 @@ def export_sw_markers(game: str, datadir: Path, sourcedir: Path):  # noqa: C901 
 
             # Grab secret required abilities if there are any
             if otype == 'SecretVolume_C' and (v := p.get('RequiredAbilities')):
-                data[-1]['abilities'] = ', '.join(
+                data[-1]['abilities'] = ','.join(
                     [a.removeprefix('GameplayAbilitySystem.Ability.').replace('.', ' ') for a in v]
                 )
 
@@ -1806,6 +1806,16 @@ brick_types = {
     4: 'gold',
 }
 
+price_types = [
+    "coin",
+    "coal",
+    "iron",
+    "diamond",
+    "supranium",
+    "scrap",
+    "bone",
+]
+
 # Number of coins given by classes if not explicit
 # Coin pots provide 1 if the flag is true
 coin_defaults = {
@@ -1921,7 +1931,10 @@ def cleanup_objects(  # noqa: C901 - disable complexity warning
         # variant is set to the brick type
         if o['type'] == 'MinecraftBrick_C':
             if game == 'siu':
-                o['variant'] = brick_types[o.get('brick_type') or (4 if o.get('coins') else 0)]
+                if type(bt := o.get('brick_type')) is str:
+                    o['variant'] = bt.rsplit('::')[-1].lower()
+                else:
+                    o['variant'] = brick_types[4 if not bt and o.get('coins') else 0]
                 if o['variant'] == 'gold' and not o.get('coins'):
                     o['coins'] = 3
                 if o.get('coins') is not None and o['variant'] != 'gold':
@@ -1940,6 +1953,11 @@ def cleanup_objects(  # noqa: C901 - disable complexity warning
             color = o.get('color') or o.get('original_color')
             if color and type(color) is int and color >= 0 and color < len(colors):
                 o['variant'] = colors[color]
+            elif color and type(color) is str and (color := color.split('::')[-1]):
+                o['variant'] = color.lower()
+
+        if (pt := o.get('price_type')) is not None and type(pt) is str:
+            o['price_type'] = price_types.index(pt.split('::')[-1].lower())
 
         # Anything that has coins gets a subclass (chests, minecraft bricks, destroyable pots...)
         # Anything that provides coins and spawns we clear the spawns field (chests can't do both)

--- a/scripts/supraland_parser.py
+++ b/scripts/supraland_parser.py
@@ -978,7 +978,7 @@ def in_earlyaccess(otype, p, pos):  # noqa: C901 - disable complexity warning
     return True
 
 
-def optEnum(s):
+def optEnum(s: str | int):
     if match := re.search('::.*([0-9]+)$', str(s)):
         return int(match.group(1))
     return s

--- a/scripts/supraland_parser.py
+++ b/scripts/supraland_parser.py
@@ -244,6 +244,9 @@ config = {
         'pathmap': {
             'Game': 'SupralandSIU/Content',
         },
+        # Note: we don't include DLC2_Menu_Splash anymore as
+        # it we find one secret and one pipe both of which are not usable
+        # DLC2_LateChanges was added more recently
         'maps': [
             'DLC2_Complete',
             'DLC2_FinalBoss',
@@ -252,7 +255,6 @@ config = {
             'DLC2_PostRainbow',
             'DLC2_Area0_Below',
             'DLC2_RainbowTown',
-            'DLC2_Menu_Splash',
             'DLC2_Splash',
             'DLC2_Menu',
             'DLC2_LateChanges',

--- a/scripts/supraland_parser.py
+++ b/scripts/supraland_parser.py
@@ -244,20 +244,18 @@ config = {
         'pathmap': {
             'Game': 'SupralandSIU/Content',
         },
-        # 'DLC2_LateChanges' contains an additional set of items which may appear in the game,
-        # but this needs to be confirmed before they are added to the map, so leaving it out
-        # for now.
         'maps': [
-            'DLC2_Area0_Below',
-            'DLC2_Area0',
             'DLC2_Complete',
             'DLC2_FinalBoss',
-            'DLC2_Menu_Splash',
-            'DLC2_Menu',
-            'DLC2_PostRainbow',
-            'DLC2_RainbowTown',
+            'DLC2_Area0',
             'DLC2_SecretLavaArea',
+            'DLC2_PostRainbow',
+            'DLC2_Area0_Below',
+            'DLC2_RainbowTown',
+            'DLC2_Menu_Splash',
             'DLC2_Splash',
+            'DLC2_Menu',
+            'DLC2_LateChanges',
         ],
     },
     'sw': {

--- a/web_src/css/main.css
+++ b/web_src/css/main.css
@@ -15,6 +15,7 @@ body,
 
 .found {
   opacity: 30%;
+  filter: grayscale(75%);
 }
 .hidden {
   visibility: hidden;


### PR DESCRIPTION
SIU instances are held in multiple map files (unlike the other games). It turns out that we were missing one of them (DLC_LateChanges.umap). This PR primarily updates the SIU markers file but as it is built with the new extraction pipeline there are other changes to the data (some objects subtly moved, filtered out some never displayed instances, some jump pad/pipe targets shifted...)

In addition it changes deploy.yml to allow manual deployment of branches to the github-pages (gh workflow run "deploy.yml" --ref "branch to deploy".

Finally an earlier change to fix the area property of the obvious secret in SW comes through in a minor data update and a fix to reverse a mistaken formatting change that came in with code cleanup.

The branch is live [here](https://jules43.github.io/maps) on jules43

Work to be completed before merge:
1. Do some checks of the live map to try to ensure no undesirable changes (like missing prices)
2. Check that the new coins etc on the map are real
3. Mark items that are unreachable so that they are not displayed
    - TJ is hopefully going to create a save that shows which need removing
