### PR TITLE
Fixed two bugs in the save handling of pipes (pipecaps) in SIU

### DIFF
--- a/web_src/mapObject.jsx
+++ b/web_src/mapObject.jsx
@@ -708,7 +708,7 @@ class MapPipesystem extends MapObject {
 
   // For two way pipes where the other end doesn't have a nearest_cap it should match found
   onSaveEvent(id, data) {
-    super.onSaveEvent();
+    super.onSaveEvent(id, data);
     if (this._triggerOtherPipe) {
       MapObject._mapObjects[this.o.other_pipe].onSaveEvent(this.o.other_pipe, data);
     }

--- a/web_src/saveFileSystem.js
+++ b/web_src/saveFileSystem.js
@@ -219,7 +219,7 @@ export class SaveFileSystem {
       if (o.name == 'ActorSaveData') {
         // This is for SIU PipeCap's
         const actorSaveData = o.value.innerValue;
-        const re_match = new RegExp('([^.:]*):PersistentLevel.([^\\0]*?pipecap[^\\0]*)', 'gi');
+        const re_match = new RegExp('(DLC2_[^\\0.:]*)[\\0][\\s\\S]{4}PersistentLevel.([^\\0]*?pipe[^\\0]*)', 'gi');
         let m;
         while ((m = re_match.exec(actorSaveData)) != null) {
           this._addToSaveData(m[1], m[2], o.name);


### PR DESCRIPTION
The event handler was being called without passing on the parameters for one end of pipes The save file format appears to have changed with the upgrade to a more recent UE version and we were not recognising the pipecaps