### PR TITLE
Save load refactor

### DIFF
--- a/scripts/export.cmd
+++ b/scripts/export.cmd
@@ -180,7 +180,7 @@ echo Data parsing:
 echo  version  update version numbers (versions.json)
 echo  preproc  outputs information about map files and applies enum mappings
 echo  markers  generates marker data from the maps
-echo  doloc    extracts .locres/.locmeta localistation files for the specified game
+echo  doloc    outputs localisation json files to public data directory
 echo.
 echo Notes:
 echo  - Run findslpaks.cmd first to setup paths

--- a/web_src/UE5SaveDecoder.js
+++ b/web_src/UE5SaveDecoder.js
@@ -2,97 +2,116 @@
 // propertly reading the .sav file format
 
 export class UE5SaveDecoder {
-  static INSTANCE_PATTERN = 'PersistentLevel.';
-
   // Setup data and string views and initialise reading index
   constructor(arrayData, outerPatterns) {
-    this.dataview = new DataView(arrayData, arrayData.byteOffset, arrayData.byteLength);
-    this.strview = new TextDecoder('latin1').decode(this.dataview);
-    this.outerPatterns = outerPatterns;
-    this.searchOffset = 0;
+    this._dataview = new DataView(arrayData, arrayData.byteOffset, arrayData.byteLength);
+    this._strview = new TextDecoder('latin1').decode(this._dataview);
+    this._outerPatterns = outerPatterns;
+    this._searchOffset = 0;
   }
 
   // Returns true if we've reached the end
   isAtEnd() {
-    return this.searchOffset == this.strview.byteLength;
+    return this._searchOffset == this._strview.byteLength;
   }
 
   // Returns the first FString that starts with any of the matchStrings (string array),
   // stopping search at end of data or if we find any of stopStrings (string array).
   // Returns the FString found or null (check isAtEnd()).
-  searchFStrings({ matchStrings = [], stopStrings = [] }) {
-    if (this.isAtEnd()) return {};
+  searchFStrings({ matchStrings = [], stopStrings = [], exact = false }) {
+    if (this.isAtEnd()) {
+      return false;
+    }
+
+    this.match = this.value = null;
+    this.found = false;
 
     // Match for any int32 in range 0000-FFFF, followed by any of the match or stop strings
     // Stores the matched string in named group 'match'
+    // Really we should escape the strings in matchStrings and stopStrings but for now they don't
+    // contain characters that require it except '.' and that will work anyway.
     const re_match = RegExp(`[\\s\\S]{2}\\0\\0(?<match>${[...matchStrings, ...stopStrings].join('|')})`, 'gi');
 
     // Start searching from last position reached
-    re_match.lastIndex = this.searchOffset;
-    const m = re_match.exec(this.strview);
+    re_match.lastIndex = this._searchOffset;
+    const m = re_match.exec(this._strview);
 
-    // If m is null, we got to the end without finding anything, so
+    // If m is null, we got to the end without finding anything, mark end
     if (m == null) {
-      this.searchOffset = this.strview.byteLength;
-      return {};
+      this._searchOffset = this._strview.byteLength;
+      return false;
     }
 
     // If we matched a stop string (that isn't in matchStrings) then this is the next search position
     if (!matchStrings?.includes(m.groups.match)) {
-      this.searchOffset = m.index;
-      return {};
+      this._searchOffset = m.index;
+      return false;
     }
 
-    // Otherwise we found a match, advance to end of FString and return the string
-    const byteLen = this.dataview.getInt32(m.index, true);
+    // Otherwise we found a match, advance to end of FString and store the match and remainder
+    const byteLen = this._dataview.getInt32(m.index, true);
     const strIdx = m.index + 4;
-    const strLen = this.dataview.getInt8(strIdx + byteLen - 1) != 0 ? byteLen : byteLen - 1;
+    const strLen = this._dataview.getInt8(strIdx + byteLen - 1) != 0 ? byteLen : byteLen - 1;
 
-    this.searchOffset = strIdx + byteLen;
-
-    if (m.groups.match == UE5SaveDecoder.INSTANCE_PATTERN) {
-      return {
-        isInstance: true,
-        found: this.strview.slice(strIdx + m.groups.match.length, strIdx + strLen),
-      };
-    } else {
-      return { found: this.strview.slice(strIdx, strIdx + strLen) };
+    if(exact && m.groups.match.length != strLen) {
+      return false;
     }
+
+    this._searchOffset = strIdx + byteLen;
+    this.match = m.groups.match;
+    this.postmatch = this._strview.slice(strIdx + this.match.length, strIdx + strLen);
+    this.found = true;
+
+    return true;
   }
 
   // Returns null or the next matching outer string
   nextOuterString() {
-    return this.searchFStrings({ matchStrings: this.outerPatterns });
+    return this.searchFStrings({ matchStrings: this._outerPatterns });
   }
 
   // Returns null or the next matching fstrings, stops if it finds an outerString
-  nextFString(fstring, { required = false } = {}) {
-    const match = this.searchFStrings({
+  nextFString(fstring, { required = false, exact = false } = {}) {
+    this.searchFStrings({
       matchStrings: [fstring],
-      stopStrings: required ? [] : this.outerPatterns,
+      stopStrings: required ? [] : this._outerPatterns,
+      exact
     });
-    if (!match.found && required) {
+    if (!this.found && required) {
       throw new Error(`Expecting instance FString:${fstring}`);
     }
-    return match;
+    return this.found;
+  }
+
+  // Returns empty dictionary or the next FString that looks like an instance
+  nextInstance({ required = false } = {}) {
+    return this.nextFString(UE5SaveDecoder.INSTANCE_PATTERN, { required, exact: false });
   }
 
   // Returns next byte property (0-255)
   nextByteProperty({ required = false } = {}) {
-    const match = this.searchFStrings({
+    this.searchFStrings({
       matchStrings: ['ByteProperty'],
-      stopStrings: required ? [] : this.outerPatterns,
+      stopStrings: required ? [] : this._outerPatterns,
+      exact: true
     });
-    if (!match.found) {
-      if (required) {
+    if (!this.found) {
+      if(required) {
         throw new Error('Expecting instance FString:ByteProperty');
       }
-      return match;
+      return false;
     }
+
+    // Skip to the byte property value
     // int32 == 0, int8 = flag == 1 (hasArrayIndex), int32 == 0
-    this.searchOffset += 4 + 1 + 4;
-    const value = this.dataview.getUint8(this.searchOffset);
-    this.searchOffset += 1;
-    return { found: value };
+    const skipBytes = '\0\0\0\0\x01\0\0\0\0';
+    if(this._strview.slice(this._searchOffset, this._searchOffset + skipBytes.length) != skipBytes){
+      throw new Error('Unexpected data following FString:ByteProperty');
+    }
+    this._searchOffset += skipBytes.length;
+    this.data = this._dataview.getUint8(this._searchOffset);
+    this._searchOffset++;
+
+    return true;
   }
 }

--- a/web_src/UE5SaveDecoder.js
+++ b/web_src/UE5SaveDecoder.js
@@ -53,7 +53,7 @@ export class UE5SaveDecoder {
     const strIdx = m.index + 4;
     const strLen = this._dataview.getInt8(strIdx + byteLen - 1) != 0 ? byteLen : byteLen - 1;
 
-    if(exact && m.groups.match.length != strLen) {
+    if (exact && m.groups.match.length != strLen) {
       return false;
     }
 
@@ -75,7 +75,7 @@ export class UE5SaveDecoder {
     this.searchFStrings({
       matchStrings: [fstring],
       stopStrings: required ? [] : this._outerPatterns,
-      exact
+      exact,
     });
     if (!this.found && required) {
       throw new Error(`Expecting instance FString:${fstring}`);
@@ -93,10 +93,10 @@ export class UE5SaveDecoder {
     this.searchFStrings({
       matchStrings: ['ByteProperty'],
       stopStrings: required ? [] : this._outerPatterns,
-      exact: true
+      exact: true,
     });
     if (!this.found) {
-      if(required) {
+      if (required) {
         throw new Error('Expecting instance FString:ByteProperty');
       }
       return false;
@@ -105,7 +105,7 @@ export class UE5SaveDecoder {
     // Skip to the byte property value
     // int32 == 0, int8 = flag == 1 (hasArrayIndex), int32 == 0
     const skipBytes = '\0\0\0\0\x01\0\0\0\0';
-    if(this._strview.slice(this._searchOffset, this._searchOffset + skipBytes.length) != skipBytes){
+    if (this._strview.slice(this._searchOffset, this._searchOffset + skipBytes.length) != skipBytes) {
       throw new Error('Unexpected data following FString:ByteProperty');
     }
     this._searchOffset += skipBytes.length;

--- a/web_src/mapObject.jsx
+++ b/web_src/mapObject.jsx
@@ -991,5 +991,5 @@ function objectToSubclass(o) {
   }
 
   // Every other object type/name
-  return mapObject;
+  return (...args) => new MapObject(...args);
 }

--- a/web_src/mapObject.jsx
+++ b/web_src/mapObject.jsx
@@ -708,7 +708,7 @@ class MapPipesystem extends MapObject {
 
   // For two way pipes where the other end doesn't have a nearest_cap it should match found
   onSaveEvent(id, data) {
-    super.onSaveEvent();
+    super.onSaveEvent(id, data);
     if (this._triggerOtherPipe) {
       MapObject._mapObjects[this.o.other_pipe].onSaveEvent(this.o.other_pipe, data);
     }

--- a/web_src/mapObject.jsx
+++ b/web_src/mapObject.jsx
@@ -611,10 +611,6 @@ export class MapObject {
   }
 }
 
-function mapObject(...args) {
-  return new MapObject(...args);
-}
-
 // Handler for found checkbox on MapObject popup
 export const mapObjectFound = function (id, found = true) {
   MapObject._mapObjects[id].setFound(found);
@@ -639,10 +635,6 @@ class MapPlayerStart extends MapObject {
       MapObject.addObjectFromJson(objJson).init(map);
     }
   }
-}
-
-function mapPlayerStart(...args) {
-  return new MapPlayerStart(...args);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -709,9 +701,6 @@ class MapPlayerPosition extends MapObject {
     MapObject.updateTitles();
   }
 }
-function mapPlayerPosition(...args) {
-  return new MapPlayerPosition(...args);
-}
 
 //-------------------------------------------------------------------------------------------------
 // MapObject subclass for o.type=='DetectiveCase_.*'
@@ -723,9 +712,6 @@ class MapDetectiveCase extends MapObject {
       SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
     }
   }
-}
-function mapDetectiveCase(...args) {
-  return new MapDetectiveCase(...args);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -740,9 +726,6 @@ class MapPuzzleCloud extends MapObject {
       SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
     }
   }
-}
-function mapPuzzleCloud(...args) {
-  return new MapPuzzleCloud(...args);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -793,9 +776,6 @@ class MapPipesystem extends MapObject {
     }
   }
 }
-function mapPipesystem(...args) {
-  return new MapPipesystem(...args);
-}
 
 //-------------------------------------------------------------------------------------------------
 // MapObject subclass for type 'Jumppad_C'
@@ -845,10 +825,6 @@ class MapJumppad extends MapObject {
     }
     super.markFound(found, lineFound);
   }
-}
-
-function mapJumppad(...args) {
-  return new MapJumppad(...args);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -917,9 +893,6 @@ class MapCoinStack extends MapObject {
     this.markFound(!this.found());
   }
 }
-function mapCoinStack(...args) {
-  return new MapCoinStack(...args);
-}
 
 //-------------------------------------------------------------------------------------------------
 // MapObject subclass for type 'Juicer_C'
@@ -939,9 +912,6 @@ class MapJuicer extends MapObject {
     }
   }
 }
-function mapJuicer(...args) {
-  return new MapJuicer(...args);
-}
 
 //-------------------------------------------------------------------------------------------------
 // MapObject subclass for type 'EnemySpawn3_C' in SL
@@ -955,10 +925,6 @@ class MapGraveVolcano extends MapObject {
   }
 }
 
-function mapGraveVolcano(...args) {
-  return new MapGraveVolcano(...args);
-}
-
 //-------------------------------------------------------------------------------------------------
 // MapObject subclass for type 'CrashEnemySpawner_C' in SLC
 //
@@ -969,9 +935,6 @@ class MapBonesSpawner extends MapObject {
       SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
     }
   }
-}
-function mapBonesSpawner(...args) {
-  return new MapBonesSpawner(...args);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -985,23 +948,20 @@ class MapDeadHeroIndy extends MapObject {
     }
   }
 }
-function mapDeadHeroIndy(...args) {
-  return new MapDeadHeroIndy(...args);
-}
 
 // Returns class to instantiate given
 function objectToSubclass(o) {
   // Object types that have MapObject an exact match
   const typeMap = {
-    _PlayerPosition: mapPlayerPosition,
-    _SWPlayerPosition: mapPlayerPosition,
-    PlayerStart: mapPlayerStart,
-    SupraworldPlayerStart_C: mapPlayerStart,
-    EnemySpawn3_C: mapGraveVolcano,
-    CrashEnemySpawner_C: mapBonesSpawner,
-    _CoinStack_C: mapCoinStack,
-    Juicer_C: mapJuicer,
-    PuzzleCloud_C: mapPuzzleCloud,
+    _PlayerPosition: (...args) => new MapPlayerPosition(...args),
+    _SWPlayerPosition: (...args) => new MapPlayerPosition(...args),
+    PlayerStart: (...args) => new MapPlayerStart(...args),
+    SupraworldPlayerStart_C: (...args) => new MapPlayerStart(...args),
+    EnemySpawn3_C: (...args) => new MapGraveVolcano(...args),
+    CrashEnemySpawner_C: (...args) => new MapBonesSpawner(...args),
+    _CoinStack_C: (...args) => new MapCoinStack(...args),
+    Juicer_C: (...args) => new MapJuicer(...args),
+    PuzzleCloud_C: (...args) => new MapPuzzleCloud(...args),
   };
 
   let cls = typeMap[o.type];
@@ -1011,9 +971,9 @@ function objectToSubclass(o) {
 
   // Types identified by substring of their type
   const typeIncludes = {
-    Pipesystem: mapPipesystem,
-    Jumppad: mapJumppad,
-    DetectiveCase_: mapDetectiveCase,
+    Pipesystem: (...args) => new MapPipesystem(...args),
+    Jumppad: (...args) => new MapJumppad(...args),
+    DetectiveCase_: (...args) => new MapDetectiveCase(...args),
   };
   for (const [typeSubStr, cls] of Object.entries(typeIncludes)) {
     if (o.type.includes(typeSubStr)) {
@@ -1023,7 +983,7 @@ function objectToSubclass(o) {
 
   // Object names that have MapObject subclass
   const nameMap = {
-    DeadHeroIndy: mapDeadHeroIndy,
+    DeadHeroIndy: (...args) => new MapDeadHeroIndy(...args),
   };
   cls = nameMap[o.name];
   if (cls) {

--- a/web_src/mapObject.jsx
+++ b/web_src/mapObject.jsx
@@ -268,7 +268,7 @@ export class MapObject {
 
     // If this marker is findable then the contextmenu and found state will
     // be set up when the save state is dealt with, so only do it now if it's unfindable
-    if(this._foundLockedState !== undefined){
+    if (this._foundLockedState !== undefined) {
       this.markFound();
     }
 
@@ -277,20 +277,20 @@ export class MapObject {
 
   // Add a default decode handler
   addSaveDecodeHandler() {
-    if(this.saveDecodeHandler) {
+    if (this.saveDecodeHandler) {
       SaveFileSystem.setDecodeHandler(
         this._decodeHandlerId || this.o.type,
         this.saveDecodeHandler,
         this._saveDecodeHandlerContext,
-        { isOuterHandler: !!this._decodeHandlerIsOuter},
+        { isOuterHandler: !!this._decodeHandlerIsOuter }
       );
     }
   }
 
   // Release default save decode handler
   releaseSaveDecodeHandler() {
-    if(this.saveDecodeHandler) {
-      SaveFileSystem.clearDecodeHandler(this._decodeHandlerId || this.o.type)
+    if (this.saveDecodeHandler) {
+      SaveFileSystem.clearDecodeHandler(this._decodeHandlerId || this.o.type);
     }
   }
 
@@ -299,12 +299,7 @@ export class MapObject {
   // saveDecodeHandler, _saveFileId and _defaultSaveData may be set by subclasses
   addSaveListeners() {
     if (this._saveFileId !== null && this._foundLockedState === undefined) {
-      SaveFileSystem.setListener(
-        this._saveFileId || this.alt,
-        this.onSaveEvent,
-        this,
-        this._defaultSaveData
-      );
+      SaveFileSystem.setListener(this._saveFileId || this.alt, this.onSaveEvent, this, this._defaultSaveData);
     }
   }
 
@@ -314,7 +309,6 @@ export class MapObject {
       SaveFileSystem.clearListener(this._saveFileId || this.alt);
     }
   }
-
 
   // Callback from saveFileSystem when save data changes
   onSaveEvent(id, data) {
@@ -528,10 +522,10 @@ export class MapObject {
   // Handler for: 'PersistentLevel.'
   static instanceDecoderHandler(saveDecoder) {
     const listenerId = MapObject.makeAlt(saveDecoder.area, saveDecoder.postmatch);
-    if(SaveFileSystem.hasListener(listenerId)) {
+    if (SaveFileSystem.hasListener(listenerId)) {
       saveDecoder.handlerId = MapObject.get(listenerId)?.o.type;
       saveDecoder.listenerId = listenerId;
-      if(!SaveFileSystem.callDecoderHandler(saveDecoder)) {
+      if (!SaveFileSystem.callDecoderHandler(saveDecoder)) {
         // There's no decode handler but there is an instance listener so
         // just add true to the save data
         SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
@@ -547,7 +541,9 @@ export class MapObject {
       mapObject.init(map);
     }
 
-    SaveFileSystem.setDecodeHandler('PersistentLevel.', this.instanceDecoderHandler, MapObject, { isOuterHandler: true });
+    SaveFileSystem.setDecodeHandler('PersistentLevel.', this.instanceDecoderHandler, MapObject, {
+      isOuterHandler: true,
+    });
 
     // Allows popup to toggle found state
     window.mapObjectFound = mapObjectFound;
@@ -662,12 +658,11 @@ class MapPlayerPosition extends MapObject {
   subclassInit(map) {
     MapObject._playerStartPosition = { lat: this.o.lat, lng: this.o.lng, alt: this.o.alt };
     this._defaultSaveData = { ...MapObject._playerStartPosition };
-    if(map.mapId == 'sw') {
+    if (map.mapId == 'sw') {
       this.saveDecodeHandler = MapPlayerPosition.lastCheckpointDecodeHandler;
       this._decodeHandlerId = 'LastCheckpointActor';
       this._decodeHandlerIsOuter = true;
-    }
-    else {
+    } else {
       this.saveDecodeHandler = MapPlayerPosition.playerPositionDecodeHandler;
       this._decodeHandlerId = this._saveFileId;
     }
@@ -676,20 +671,19 @@ class MapPlayerPosition extends MapObject {
   static lastCheckpointDecodeHandler(saveDecoder) {
     saveDecoder.nextInstance({ require: true });
     const instanceName = saveDecoder.postmatch;
-    if(instanceName) {
+    if (instanceName) {
       const id = MapObject.makeAlt('Supraworld', instanceName);
       const checkPoint = MapObject.get(id);
       saveDecoder.listenerId = 'Player Position';
       saveDecoder.data = { lat: checkPoint.o.lat, lng: checkPoint.o.lng, z: checkPoint.o.alt };
       SaveFileSystem.defaultDecodeHandler(saveDecoder);
-    }
-    else {
-      console.log("Warning: last checkpoint was not recognised (OOB?)");
+    } else {
+      console.log('Warning: last checkpoint was not recognised (OOB?)');
     }
   }
 
   static playerPositionDecodeHandler(saveDecoder) {
-    if(saveDecoder.data) {
+    if (saveDecoder.data) {
       saveDecoder.listenerId = saveDecoder.handlerId;
       saveDecoder.data = saveDecoder.data.Translation?.value || saveDecoder.data.value || saveDecoder.data;
       saveDecoder.data = { lat: saveDecoder.data.y, lng: saveDecoder.data.x, alt: saveDecoder.data.z };
@@ -702,12 +696,11 @@ class MapPlayerPosition extends MapObject {
   onSaveEvent(id, data) {
     if (data) {
       Object.assign(this.o, data);
-    }
-    else {
+    } else {
       console.log('MapPlayerPosition.onSaveEvent called with null data');
       Object.assign(this.o, MapObject._playerStartPosition);
     }
-    this.setLatLng({lat: this.o.lat, lng: this.o.lng});
+    this.setLatLng({ lat: this.o.lat, lng: this.o.lng });
 
     // Contents of popup may change
     (this.primeMarker || this.groupMarker)?.closePopup();
@@ -726,7 +719,7 @@ function mapPlayerPosition(...args) {
 // The detective cases need to check if someone has been arrested to be considered found
 class MapDetectiveCase extends MapObject {
   saveDecodeHandler(saveDecoder) {
-    if(saveDecoder.nextFString('DetainedCharacter')) {
+    if (saveDecoder.nextFString('DetainedCharacter')) {
       SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
     }
   }
@@ -740,10 +733,10 @@ function mapDetectiveCase(...args) {
 //
 // Puzzle cloud's must have had their state set to post puzzle to be considered found
 class MapPuzzleCloud extends MapObject {
-  saveDecodeHandler(saveDecoder){
+  saveDecodeHandler(saveDecoder) {
     // Value is from enumeration blueprint EPuzzleCloudState
     const EPuzzleCloudState_PostPuzzle = 2;
-    if(saveDecoder.nextByteProperty() && saveDecoder.data == EPuzzleCloudState_PostPuzzle){
+    if (saveDecoder.nextByteProperty() && saveDecoder.data == EPuzzleCloudState_PostPuzzle) {
       SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
     }
   }
@@ -831,8 +824,7 @@ class MapJumppad extends MapObject {
 
   // Overloading of markFound to handle special line behaviour
   markFound(found) {
-    if(this.o.name == 'Jumppad16')
-      console.log(this.o.name);
+    if (this.o.name == 'Jumppad16') console.log(this.o.name);
     if (found == undefined) {
       found = this.isFound();
     }
@@ -956,7 +948,7 @@ function mapJuicer(...args) {
 //
 // Only mark found if the parent array is ThingsToOpenForever
 class MapGraveVolcano extends MapObject {
-  saveDecodeHandler(saveDecoder){
+  saveDecodeHandler(saveDecoder) {
     if (saveDecoder.parent == 'ThingsToOpenForever') {
       SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
     }
@@ -972,7 +964,7 @@ function mapGraveVolcano(...args) {
 //
 // Only mark found if the parent array is ThingsToRemove
 class MapBonesSpawner extends MapObject {
-  saveDecodeHandler(saveDecoder){
+  saveDecodeHandler(saveDecoder) {
     if (saveDecoder.parent == 'ThingsToRemove') {
       SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
     }
@@ -999,7 +991,6 @@ function mapDeadHeroIndy(...args) {
 
 // Returns class to instantiate given
 function objectToSubclass(o) {
-
   // Object types that have MapObject an exact match
   const typeMap = {
     _PlayerPosition: mapPlayerPosition,

--- a/web_src/mapObject.jsx
+++ b/web_src/mapObject.jsx
@@ -28,7 +28,6 @@ import { marker as leaflet_marker, latLngBounds } from 'leaflet';
 // Optional instance data members that can be set by subclasses:
 //
 //  _saveFileId                - optional id listened to for save listener (not set => alt)
-//  _saveFilter                - optional filter to apply for save listener
 //  _defaultSaveValue          - optonal default value for save listener (normally false)
 //  _foundLockedState          - optional, if set found will be locked to this value
 //
@@ -263,27 +262,47 @@ export class MapObject {
 
     this.createLines(map);
 
+    this.addSaveDecodeHandler();
+
     this.addSaveListeners();
 
-    // If this marker is findable then the context menu will be set up when
-    // the save state is dealt with, so only do it now if it's unfindable
-    if (this._foundLockedState !== undefined) {
-      this.updateContextMenuOptions();
+    // If this marker is findable then the contextmenu and found state will
+    // be set up when the save state is dealt with, so only do it now if it's unfindable
+    if(this._foundLockedState !== undefined){
+      this.markFound();
     }
 
     return this;
   }
 
+  // Add a default decode handler
+  addSaveDecodeHandler() {
+    if(this.saveDecodeHandler) {
+      SaveFileSystem.setDecodeHandler(
+        this._decodeHandlerId || this.o.type,
+        this.saveDecodeHandler,
+        this._saveDecodeHandlerContext,
+        { isOuterHandler: !!this._decodeHandlerIsOuter},
+      );
+    }
+  }
+
+  // Release default save decode handler
+  releaseSaveDecodeHandler() {
+    if(this.saveDecodeHandler) {
+      SaveFileSystem.clearDecodeHandler(this._decodeHandlerId || this.o.type)
+    }
+  }
+
   // Default behaviour is to add a save file listener with 'alt' (or the _saveFileId member if set)
   // This default behaviour can be cancelled by setting _saveFileId to null
-  // _saveFileId, _filter and _defaultSaveData may be set by subclasses
+  // saveDecodeHandler, _saveFileId and _defaultSaveData may be set by subclasses
   addSaveListeners() {
-    if (this._saveFileId !== null /*&& this._foundLockedState === undefined*/) {
+    if (this._saveFileId !== null && this._foundLockedState === undefined) {
       SaveFileSystem.setListener(
         this._saveFileId || this.alt,
         this.onSaveEvent,
         this,
-        this._saveFilter,
         this._defaultSaveData
       );
     }
@@ -291,10 +310,11 @@ export class MapObject {
 
   // Release a listener if we've set one up
   releaseSaveListeners() {
-    if (this._saveFileId !== null) {
+    if (this._saveFileId !== null && this._foundLockedState === undefined) {
       SaveFileSystem.clearListener(this._saveFileId || this.alt);
     }
   }
+
 
   // Callback from saveFileSystem when save data changes
   onSaveEvent(id, data) {
@@ -504,6 +524,21 @@ export class MapObject {
     }
   }
 
+  // Get the instance's type and use that as to find the decoder
+  // Handler for: 'PersistentLevel.'
+  static instanceDecoderHandler(saveDecoder) {
+    const listenerId = MapObject.makeAlt(saveDecoder.area, saveDecoder.postmatch);
+    if(SaveFileSystem.hasListener(listenerId)) {
+      saveDecoder.handlerId = MapObject.get(listenerId)?.o.type;
+      saveDecoder.listenerId = listenerId;
+      if(!SaveFileSystem.callDecoderHandler(saveDecoder)) {
+        // There's no decode handler but there is an instance listener so
+        // just add true to the save data
+        SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
+      }
+    }
+  }
+
   // Called after loadObjects to add all the markers to the map
   static initObjects(map) {
     // Initialise all the objects we've constructed
@@ -511,6 +546,8 @@ export class MapObject {
       // Use values so object can release itself if required
       mapObject.init(map);
     }
+
+    SaveFileSystem.setDecodeHandler('PersistentLevel.', this.instanceDecoderHandler, MapObject, { isOuterHandler: true });
 
     // Allows popup to toggle found state
     window.mapObjectFound = mapObjectFound;
@@ -622,48 +659,97 @@ class MapPlayerPosition extends MapObject {
   _foundLockedState = false;
   _disableMovePlayerPosition = true;
 
-  subclassInit() {
+  subclassInit(map) {
     MapObject._playerStartPosition = { lat: this.o.lat, lng: this.o.lng, alt: this.o.alt };
     this._defaultSaveData = { ...MapObject._playerStartPosition };
+    if(map.mapId == 'sw') {
+      this.saveDecodeHandler = MapPlayerPosition.lastCheckpointDecodeHandler;
+      this._decodeHandlerId = 'LastCheckpointActor';
+      this._decodeHandlerIsOuter = true;
+    }
+    else {
+      this.saveDecodeHandler = MapPlayerPosition.playerPositionDecodeHandler;
+      this._decodeHandlerId = this._saveFileId;
+    }
+  }
+
+  static lastCheckpointDecodeHandler(saveDecoder) {
+    saveDecoder.nextInstance({ require: true });
+    const instanceName = saveDecoder.postmatch;
+    if(instanceName) {
+      const id = MapObject.makeAlt('Supraworld', instanceName);
+      const checkPoint = MapObject.get(id);
+      saveDecoder.listenerId = 'Player Position';
+      saveDecoder.data = { lat: checkPoint.o.lat, lng: checkPoint.o.lng, z: checkPoint.o.alt };
+      SaveFileSystem.defaultDecodeHandler(saveDecoder);
+    }
+    else {
+      console.log("Warning: last checkpoint was not recognised (OOB?)");
+    }
+  }
+
+  static playerPositionDecodeHandler(saveDecoder) {
+    if(saveDecoder.data) {
+      saveDecoder.listenerId = saveDecoder.handlerId;
+      saveDecoder.data = saveDecoder.data.Translation?.value || saveDecoder.data.value || saveDecoder.data;
+      saveDecoder.data = { lat: saveDecoder.data.y, lng: saveDecoder.data.x, alt: saveDecoder.data.z };
+      SaveFileSystem.defaultDecodeHandler(saveDecoder);
+    }
   }
 
   // We're listening for a saveLoadEvent of Player Position. We will be called with a position
   // if one has been loaded, otherwise the save state must be cleared.
   onSaveEvent(id, data) {
-    if (!data) {
-      Object.assign(this.o, MapObject._playerStartPosition);
-      this.setLatLng({ lat: this.o.lat, lng: this.o.lng });
-
-      // Mouse over / search titles which include the relative altitude may have changed
-      MapObject.updateTitles();
-    } else {
-      if (this.primeMarker) {
-        this.primeMarker.closePopup();
-      }
-      if (this.groupMarker) {
-        this.groupMarker.closePopup();
-      }
-
-      let value;
-      if ('Translation' in data) {
-        value = data['Translation'].value;
-      } else {
-        value = data.value;
-      }
-      if (value) {
-        this.o.alt = value.z;
-        this.setLatLng({ lat: value.y, lng: value.x });
-
-        // Mouse over / search titles which include the relative altitude may have changed
-        MapObject.updateTitles();
-      } else {
-        return;
-      }
+    if (data) {
+      Object.assign(this.o, data);
     }
+    else {
+      console.log('MapPlayerPosition.onSaveEvent called with null data');
+      Object.assign(this.o, MapObject._playerStartPosition);
+    }
+    this.setLatLng({lat: this.o.lat, lng: this.o.lng});
+
+    // Contents of popup may change
+    (this.primeMarker || this.groupMarker)?.closePopup();
+
+    // Mouse over / search titles which include the relative altitude may have changed
+    MapObject.updateTitles();
   }
 }
 function mapPlayerPosition(...args) {
   return new MapPlayerPosition(...args);
+}
+
+//-------------------------------------------------------------------------------------------------
+// MapObject subclass for o.type=='DetectiveCase_.*'
+//
+// The detective cases need to check if someone has been arrested to be considered found
+class MapDetectiveCase extends MapObject {
+  saveDecodeHandler(saveDecoder) {
+    if(saveDecoder.nextFString('DetainedCharacter')) {
+      SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
+    }
+  }
+}
+function mapDetectiveCase(...args) {
+  return new MapDetectiveCase(...args);
+}
+
+//-------------------------------------------------------------------------------------------------
+// MapObject subclass for o.type=='PuzzleCloud_C'
+//
+// Puzzle cloud's must have had their state set to post puzzle to be considered found
+class MapPuzzleCloud extends MapObject {
+  saveDecodeHandler(saveDecoder){
+    // Value is from enumeration blueprint EPuzzleCloudState
+    const EPuzzleCloudState_PostPuzzle = 2;
+    if(saveDecoder.nextByteProperty() && saveDecoder.data == EPuzzleCloudState_PostPuzzle){
+      SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
+    }
+  }
+}
+function mapPuzzleCloud(...args) {
+  return new MapPuzzleCloud(...args);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -708,7 +794,7 @@ class MapPipesystem extends MapObject {
 
   // For two way pipes where the other end doesn't have a nearest_cap it should match found
   onSaveEvent(id, data) {
-    super.onSaveEvent();
+    super.onSaveEvent(id, data);
     if (this._triggerOtherPipe) {
       MapObject._mapObjects[this.o.other_pipe].onSaveEvent(this.o.other_pipe, data);
     }
@@ -745,6 +831,8 @@ class MapJumppad extends MapObject {
 
   // Overloading of markFound to handle special line behaviour
   markFound(found) {
+    if(this.o.name == 'Jumppad16')
+      console.log(this.o.name);
     if (found == undefined) {
       found = this.isFound();
     }
@@ -866,10 +954,15 @@ function mapJuicer(...args) {
 //-------------------------------------------------------------------------------------------------
 // MapObject subclass for type 'EnemySpawn3_C' in SL
 //
-// Only mark found if the alt id is on ThingsToOpenForever
+// Only mark found if the parent array is ThingsToOpenForever
 class MapGraveVolcano extends MapObject {
-  _saveFilter = 'ThingsToOpenForever';
+  saveDecodeHandler(saveDecoder){
+    if (saveDecoder.parent == 'ThingsToOpenForever') {
+      SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
+    }
+  }
 }
+
 function mapGraveVolcano(...args) {
   return new MapGraveVolcano(...args);
 }
@@ -877,9 +970,13 @@ function mapGraveVolcano(...args) {
 //-------------------------------------------------------------------------------------------------
 // MapObject subclass for type 'CrashEnemySpawner_C' in SLC
 //
-// Only mark found if the alt id is on ThingsToRemove
+// Only mark found if the parent array is ThingsToRemove
 class MapBonesSpawner extends MapObject {
-  _saveFilter = 'ThingsToRemove';
+  saveDecodeHandler(saveDecoder){
+    if (saveDecoder.parent == 'ThingsToRemove') {
+      SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
+    }
+  }
 }
 function mapBonesSpawner(...args) {
   return new MapBonesSpawner(...args);
@@ -888,9 +985,13 @@ function mapBonesSpawner(...args) {
 //-------------------------------------------------------------------------------------------------
 // MapObject subclass for dead hero named 'DeadHeroIndy' in SL
 //
-// Only mark found if the alt id is on ThingsToActivate
+// Only mark found if the parent array is ThingsToActivate
 class MapDeadHeroIndy extends MapObject {
-  _saveFilter = 'ThingsToActivate';
+  saveDecodeHandler(saveDecoder) {
+    if (saveDecoder.parent == 'ThingsToActivate') {
+      SaveFileSystem.defaultDecodeHandler(saveDecoder, true);
+    }
+  }
 }
 function mapDeadHeroIndy(...args) {
   return new MapDeadHeroIndy(...args);
@@ -898,7 +999,8 @@ function mapDeadHeroIndy(...args) {
 
 // Returns class to instantiate given
 function objectToSubclass(o) {
-  // Object types that have MapObject subclass
+
+  // Object types that have MapObject an exact match
   const typeMap = {
     _PlayerPosition: mapPlayerPosition,
     _SWPlayerPosition: mapPlayerPosition,
@@ -908,10 +1010,24 @@ function objectToSubclass(o) {
     CrashEnemySpawner_C: mapBonesSpawner,
     _CoinStack_C: mapCoinStack,
     Juicer_C: mapJuicer,
+    PuzzleCloud_C: mapPuzzleCloud,
   };
+
   let cls = typeMap[o.type];
   if (cls) {
     return cls;
+  }
+
+  // Types identified by substring of their type
+  const typeIncludes = {
+    Pipesystem: mapPipesystem,
+    Jumppad: mapJumppad,
+    DetectiveCase_: mapDetectiveCase,
+  };
+  for (const [typeSubStr, cls] of Object.entries(typeIncludes)) {
+    if (o.type.includes(typeSubStr)) {
+      return cls;
+    }
   }
 
   // Object names that have MapObject subclass
@@ -921,17 +1037,6 @@ function objectToSubclass(o) {
   cls = nameMap[o.name];
   if (cls) {
     return cls;
-  }
-
-  // Types identified by substring that have
-  const typeIncludes = [
-    ['Pipesystem', mapPipesystem],
-    ['Jumppad', mapJumppad],
-  ];
-  for (const entry of typeIncludes) {
-    if (o.type.includes(entry[0])) {
-      return entry[1];
-    }
   }
 
   // Every other object type/name

--- a/web_src/saveFileSystem.js
+++ b/web_src/saveFileSystem.js
@@ -15,10 +15,9 @@ export class SaveFileSystem {
   static _decodeHandlers = {};
   static _outerHandlerIds = [];
 
-
   static _falseFn() {
     return false;
-  };
+  }
 
   //-----------------------------------------------------------------------------------------------
   // Save event liseners are called whenever the save data associated with the id
@@ -80,13 +79,13 @@ export class SaveFileSystem {
   }
 
   // Set the decodeHandler for a specific instance type or key string
-  static setDecodeHandler(handlerId, fn, context, { isOuterHandler = false }={}) {
+  static setDecodeHandler(handlerId, fn, context, { isOuterHandler = false } = {}) {
     const decodeHandler = (this._decodeHandlers[handlerId] = { fn });
-    if(context !== undefined) {
+    if (context !== undefined) {
       decodeHandler.ctx = context;
     }
-    if(isOuterHandler){
-      this._outerHandlerIds.push(handlerId)
+    if (isOuterHandler) {
+      this._outerHandlerIds.push(handlerId);
     }
   }
 
@@ -97,7 +96,7 @@ export class SaveFileSystem {
       delete this._decodeHandlers[handlerId];
     }
     const idx = this._outerHandlerIds.indexOf(handlerId);
-    if(idx > -1) {
+    if (idx > -1) {
       this._outerHandlerIds.splice(idx, 1);
     }
   }
@@ -106,7 +105,7 @@ export class SaveFileSystem {
   // file such as LastCheckpointActor)
   static callDecoderHandler(saveDecoder) {
     const decodeHandler = this._decodeHandlers[saveDecoder.handlerId];
-    if(decodeHandler) {
+    if (decodeHandler) {
       decodeHandler.fn.call(decodeHandler.context, saveDecoder);
       return true;
     }
@@ -195,7 +194,6 @@ export class SaveFileSystem {
     }
   }
 
-
   //-----------------------------------------------------------------------------------------------
   // Read array data loaded from Suprworld UE5 save file and call any listeners
   // to filter the data and save to settiings
@@ -205,8 +203,8 @@ export class SaveFileSystem {
     const saveDecoder = new UE5SaveDecoder(arrayData, this._outerHandlerIds);
     saveDecoder.area = 'Supraworld';
     while (saveDecoder.nextOuterString()) {
-        saveDecoder.handlerId = saveDecoder.match;
-        this.callDecoderHandler(saveDecoder);
+      saveDecoder.handlerId = saveDecoder.match;
+      this.callDecoderHandler(saveDecoder);
     }
 
     Settings.commit();
@@ -257,11 +255,11 @@ export class SaveFileSystem {
           }
         }
       } else {
-        if(o.name == 'Player Position') {
+        if (o.name == 'Player Position') {
           console.log(o.name);
         }
         // Mostly Player upgrade and other properties
-        this.callDecoderHandler({ handlerId: o.name, data: o.value})
+        this.callDecoderHandler({ handlerId: o.name, data: o.value });
       }
     }
 

--- a/web_src/saveFileSystem.js
+++ b/web_src/saveFileSystem.js
@@ -219,7 +219,7 @@ export class SaveFileSystem {
       if (o.name == 'ActorSaveData') {
         // This is for SIU PipeCap's
         const actorSaveData = o.value.innerValue;
-        const re_match = new RegExp('([^.:]*):PersistentLevel.([^\\0]*?pipecap[^\\0]*)', 'gi');
+        const re_match = new RegExp('(DLC2_[^\\0.:]*)[\\0][\\s\\S]{4}PersistentLevel.([^\\0]*?pipe[^\\0]*)', 'gi');
         let m;
         while ((m = re_match.exec(actorSaveData)) != null) {
           this._addToSaveData(m[1], m[2], o.name);

--- a/web_src/saveFileSystem.js
+++ b/web_src/saveFileSystem.js
@@ -12,36 +12,35 @@ import { UE5SaveDecoder } from './UE5SaveDecoder.js';
 
 export class SaveFileSystem {
   static _listeners = {};
+  static _decodeHandlers = {};
+  static _outerHandlerIds = [];
 
-  static _falseFn = () => {
+
+  static _falseFn() {
     return false;
   };
 
+  //-----------------------------------------------------------------------------------------------
+  // Save event liseners are called whenever the save data associated with the id
+  // is changed (set, loaded or cleared). The id is typically instance {area}:{name}
+  // but can be any key string.
+
+  // Return true if there is a listener for the specified id
   static hasListener(id) {
     return id in this._listeners;
   }
 
-  static hasAnyData() {
-    for (const id in Settings.map.saveData) {
-      return true;
-    }
-    return false;
-  }
-
-  // Add function/context to be called when event fired. Overwrites any previous listener
-  // id: string: identifies instance this listener is for '{area}:{name}'
+  // Add function to be called when the save data change event is fired fired. Overwrites
+  // any previous listener.
+  //
+  // id: string: identifies instance this listener (usually instance id '{area}:{name}')
   // fn: function(ctx: any, id: string, data: varies): called when save data for instance changes
-  // filter: string: if string passed in, will be used to filter data
   // context: object: used as this pointer for callbacks
   // defaultValue: any: data specific to listener instance class [false]
-  // decodeData: function(ctx, ?): called to allow custom save data decoding,
-  static setListener(id, fn, context, filter, defaultValue) {
+  static setListener(id, fn, context, defaultValue = false) {
     const listener = (this._listeners[id] = { fn });
     if (context !== undefined) {
       listener.ctx = context;
-    }
-    if (typeof filter === 'string') {
-      listener.flt = filter;
     }
     if (defaultValue !== undefined) {
       listener.def = defaultValue;
@@ -56,29 +55,97 @@ export class SaveFileSystem {
     }
   }
 
-  // Returns true if there is a listener and filter passes
-  static _testFire(id, filter) {
-    const listener = this._listeners[id];
-    return listener && (listener.flt === undefined || listener.flt == filter);
-  }
-
   // Call all functions listening for event
-  static _fire(id, data) {
+  static callListener(id, data) {
     const listener = this._listeners[id];
     if (listener) {
       listener.fn.call(listener.ctx, id, data);
+      return true;
+    }
+    return false;
+  }
+
+  //-----------------------------------------------------------------------------------------------
+  // Decode handlers are called when the save data is read from the file, the default only handles
+  // instances, if they are present in the file then the listener is called with 'true'.
+  //
+  // To customise behaviour for non-instance strings or specific properties within instance data
+  // a decoderHandler is called to provide the opportunity to transform what is done.
+  //
+  // Id is normally a game class, but can be any string.
+
+  // Returns true if there is a decodeHandler associated with this id
+  static hasDecodeHandler(handlerId) {
+    return handlerId in this._decodeHandlers;
+  }
+
+  // Set the decodeHandler for a specific instance type or key string
+  static setDecodeHandler(handlerId, fn, context, { isOuterHandler = false }={}) {
+    const decodeHandler = (this._decodeHandlers[handlerId] = { fn });
+    if(context !== undefined) {
+      decodeHandler.ctx = context;
+    }
+    if(isOuterHandler){
+      this._outerHandlerIds.push(handlerId)
     }
   }
 
-  // Clear all listeners (without calling)
+  // Clear the corresponding decode handler
+  static clearDecodeHandler(handlerId) {
+    if (handlerId in this._decodeHandlers) {
+      this._decodeHandlers[handlerId].fn = this._falseFn;
+      delete this._decodeHandlers[handlerId];
+    }
+    const idx = this._outerHandlerIds.indexOf(handlerId);
+    if(idx > -1) {
+      this._outerHandlerIds.splice(idx, 1);
+    }
+  }
+
+  // If there's a decoder then call it (used for global properties in save
+  // file such as LastCheckpointActor)
+  static callDecoderHandler(saveDecoder) {
+    const decodeHandler = this._decodeHandlers[saveDecoder.handlerId];
+    if(decodeHandler) {
+      decodeHandler.fn.call(decodeHandler.context, saveDecoder);
+      return true;
+    }
+    return false;
+  }
+
+  // If there is a listener for this object then add it as found (data)
+  static defaultDecodeHandler(saveDecoder, data) {
+    Settings.map.saveData[saveDecoder.listenerId] = data || saveDecoder.data;
+  }
+
+  //-----------------------------------------------------------------------------------------------
+  // Clear all listeners and handlers (without calling)
   static reset() {
     for (const listener of Object.values(this._listeners)) {
       listener.fn = this._falseFn;
     }
     this._listeners = {};
+
+    for (const decodeHandler of Object.values(this._decodeHandlers)) {
+      decodeHandler.fn = this._falseFn;
+    }
+    this._decodeHandlers = {};
+    this._outerHandlerIds = [];
   }
 
-  // Retrieve current value of property 'name'
+  //-----------------------------------------------------------------------------------------------
+  // The current state of the save data loaded is stored in Settings so that
+  // it persists between sessions.
+
+  // Returns true if there is any save data at the moment
+  static hasAnyData() {
+    for (const id in Settings.map.saveData) {
+      return true;
+    }
+    return false;
+  }
+
+  // Retrieve current value of id
   static getData(id) {
     let data = Settings.map.saveData[id];
     if (data !== undefined) {
@@ -91,19 +158,17 @@ export class SaveFileSystem {
   // Called to set property to a specific value (commits Settings so inefficient for multiple calls)
   static setData(id, data) {
     const listener = this._listeners[id];
-    if (!listener) {
-      return;
-    }
+    if (listener) {
+      const defaultValue = listener.def ?? false;
+      if (data === defaultValue) {
+        delete Settings.map.saveData[id];
+      } else {
+        Settings.map.saveData[id] = data;
+      }
+      Settings.commit();
 
-    const defaultValue = listener.def !== undefined ? listener.def : false;
-    if (data === defaultValue) {
-      delete Settings.map.saveData[id];
-    } else {
-      Settings.map.saveData[id] = data;
+      this.callListener(id, data);
     }
-    Settings.commit();
-
-    this._fire(id, data);
   }
 
   // Should be called after all listeners are established. Listeners are presumed to be
@@ -114,7 +179,7 @@ export class SaveFileSystem {
     for (const id in this._listeners) {
       const data = this.getData(id);
       if (data !== undefined) {
-        this._fire(id, data);
+        this.callListener(id, data);
       }
     }
   }
@@ -126,72 +191,27 @@ export class SaveFileSystem {
 
     for (const id in this._listeners) {
       const defaultValue = this._listeners[id].def;
-      this._fire(id, defaultValue !== undefined ? defaultValue : false);
+      this.callListener(id, defaultValue !== undefined ? defaultValue : false);
     }
   }
 
-  // If there is a listener for this object then add it as found (data)
-  static _addToSaveData = (area, name, filter, data = true) => {
-    const id = MapObject.makeAlt(area, name);
-    if (this._testFire(id, filter)) {
-      Settings.map.saveData[id] = data;
-    }
-  };
 
-  // TODO: Complete Refactor
-  // At the moment the special behaviour for classes is handled by the processLoadedArray but
-  // this can be moved into the MapObject subclasses by adding a decoder callback to the listener,
-  // whose job would be to do any further decoding required to get the state before calling the
-  // add function.
-  //
-  // The decoder callback would be passed the UE5SaveDecoder, the default decode being
-  // just calling with true if the instance is found in the file.
-  //
-  // Similarly the LastcheckpointActor string should be being added as a listener for the
-  // _PlayerPosition object, which would just move pass the listener the instance and
-  // which would then move itself to the new location.
-  //
-  // The old SL save handling will likely require some tweaking, if it uses the decode
-  // pattern it would probably make most sense to just set the filter string as a property
-  // and let the handlers query it.
-
+  //-----------------------------------------------------------------------------------------------
   // Read array data loaded from Suprworld UE5 save file and call any listeners
   // to filter the data and save to settiings
   static _processLoadedArray_sw(arrayData) {
-    const self = this;
-
     this.ClearAll();
 
-    const outerStrings = [UE5SaveDecoder.INSTANCE_PATTERN, 'LastCheckpointActor'];
-    const saveDecoder = new UE5SaveDecoder(arrayData, outerStrings);
-
-    let m;
-    while ((m = saveDecoder.nextOuterString()).found) {
-      if (m.isInstance) {
-        const map = 'Supraworld',
-          name = m.found;
-        const type = MapObject.get(MapObject.makeAlt(map, name))?.o.type;
-        if (
-          type &&
-          ((type == 'PuzzleCloud_C' && saveDecoder.nextByteProperty().found != 2) ||
-            (type.startsWith('DetectiveCase_') && saveDecoder.nextFString('DetainedCharacter').found == undefined))
-        ) {
-          continue;
-        }
-        self._addToSaveData(map, name);
-      } else {
-        // LastCheckpointActor
-        m = saveDecoder.nextFString(UE5SaveDecoder.INSTANCE_PATTERN, { required: true });
-        const saveObj = MapObject.get('Supraworld:' + m.found);
-        self._addToSaveData('', 'Player Position', null, {
-          value: { x: saveObj.o.lng, y: saveObj.o.lat, z: saveObj.o.alt },
-        });
-      }
+    const saveDecoder = new UE5SaveDecoder(arrayData, this._outerHandlerIds);
+    saveDecoder.area = 'Supraworld';
+    while (saveDecoder.nextOuterString()) {
+        saveDecoder.handlerId = saveDecoder.match;
+        this.callDecoderHandler(saveDecoder);
     }
 
     Settings.commit();
     for (const id in Settings.map.saveData) {
-      this._fire(id, Settings.map.saveData[id]);
+      this.callListener(id, Settings.map.saveData[id]);
     }
   }
 
@@ -219,10 +239,10 @@ export class SaveFileSystem {
       if (o.name == 'ActorSaveData') {
         // This is for SIU PipeCap's
         const actorSaveData = o.value.innerValue;
-        const re_match = new RegExp('([^.:]*):PersistentLevel.([^\\0]*?pipecap[^\\0]*)', 'gi');
+        const re_match = new RegExp('(DLC2_[^\\0.:]*)[\\0][\\s\\S]{4}PersistentLevel.([^\\0]*?pipe[^\\0]*)', 'gi');
         let m;
         while ((m = re_match.exec(actorSaveData)) != null) {
-          this._addToSaveData(m[1], m[2], o.name);
+          this.callDecoderHandler({ parent: o.name, area: m[1], handlerId: 'PersistentLevel.', postmatch: m[2] });
         }
       } else if (o.type == 'ArrayProperty') {
         // One of 'ThingsToRemove', 'ThingsToActivate', 'ThingsToOpenForever'
@@ -232,18 +252,22 @@ export class SaveFileSystem {
           let name = x.split('.').pop();
           if (name != 'None') {
             name = name.capitalised(); // Shell2_1957 appears as shell2_1957 in the save file
-            this._addToSaveData(area, name, o.name);
+
+            this.callDecoderHandler({ parent: o.name, area: area, handlerId: 'PersistentLevel.', postmatch: name });
           }
         }
       } else {
+        if(o.name == 'Player Position') {
+          console.log(o.name);
+        }
         // Mostly Player upgrade and other properties
-        this._addToSaveData('', o.name, null, o.value);
+        this.callDecoderHandler({ handlerId: o.name, data: o.value})
       }
     }
 
     Settings.commit();
     for (const id in Settings.map.saveData) {
-      this._fire(id, Settings.map.saveData[id]);
+      this.callListener(id, Settings.map.saveData[id]);
     }
   }
 


### PR DESCRIPTION
This is in draft because the changes are complicated and I want to do some more testing.

It seems to cover all the existing cases plus in testing it I found and fixed some other bugs.

The savefilesystem and mapobject modules should probably both be split up further, so I may take a further pass at it later,  but this should cover most things I can think of, and has at least made it easier for me to understand how it should work.

Save handling is basically two event systems and is the majority of what the subclass stuff in MapObject is doing.

When the save file is loaded we walk through looking for strings relating to specific properties or specific map markers. These are then decoded by a default handler or by a custom decoder for the type of marker.

Once the data has been decoded an event is triggered and the map marker instances all listen for their specific event.

When we load data from the settings we call the same events.

I plan to make this PR public on my fork and do a little more testing and see if anyone in the discord has a reason to use it to. Test it some more myself. And probably wait until the other PRs have landed.

I appreciate this might be a somewhat difficult PR to review.
